### PR TITLE
Translate all Portuguese prompts, comments, and messages to English.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,34 @@
-🧠 Open-Manus-BR — Fork avançado e adaptado do Foundation Agents OpenMANUS
-Este repositório é um fork do Foundation Agents (OpenMANUS), reestruturado e ampliado para tornar a automação por agentes de IA mais robusta, flexível e adaptada ao contexto brasileiro.
-Todo o desenvolvimento foi assistido por IA, incorporando diversas ideias originais do prompt Manus, mas trazendo melhorias de performance e organização.
+🧠 Open-Manus-BR — Advanced and adapted fork of Foundation Agents OpenMANUS
+This repository is a fork of Foundation Agents (OpenMANUS), restructured and expanded to make AI agent automation more robust, flexible, and adapted to the Brazilian context.
+All development was AI-assisted, incorporating several original ideas from the Manus prompt, but bringing performance and organizational improvements.
 
-Funcionalidades Principais
-🔄 Controle total do loop e execução prolongada:
-O agente não encerra tarefas sem a autorização do usuário, permitindo execuções prolongadas que podem durar até 7 dias seguidos — ideal para processos intensivos como web scraping, automação de tarefas extensas e experimentos em machine learning.
+Main Features
+🔄 Full loop control and prolonged execution:
+The agent does not end tasks without user authorization, allowing prolonged executions that can last up to 7 consecutive days — ideal for intensive processes such as web scraping, extensive task automation, and machine learning experiments.
 
-✋ Intervenção humana facilitada (AskHuman):
-Se houver dúvida, falha ou necessidade de decisão, o sistema pode acionar o usuário no meio da execução, perguntando como deve proceder, evitando travamentos e melhorando a colaboração homem-máquina.
+✋ Facilitated human intervention (AskHuman):
+If there is doubt, failure, or need for a decision, the system can trigger the user mid-execution, asking how to proceed, avoiding freezes and improving human-machine collaboration.
 
-⏸️ Pausa e controle de execução:
-O usuário pode pausar, retomar ou cancelar processos com facilidade (inclusive usando CTRL-C duas vezes para interromper execuções demoradas).
+⏸️ Pause and execution control:
+The user can pause, resume, or cancel processes easily (including using CTRL-C twice to interrupt long-running executions).
 
-🛠️ Agente de autodiagnóstico:
-Um agente especializado monitora os processos em tempo real, identificando falhas e ajudando na manutenção proativa.
+🛠️ Self-diagnostic agent:
+A specialized agent monitors processes in real-time, identifying failures and helping with proactive maintenance.
 
-🗂️ Organização e fragmentação inteligente das tarefas:
-O sistema passou por uma profunda reorganização do prompt (inspirado no Manus original), o que gerou ganhos perceptíveis de performance e organização. Agora, os agentes fragmentam as tarefas automaticamente e executam cada etapa de forma sequencial e mais eficiente.
+🗂️ Organization and intelligent task fragmentation:
+The system underwent a profound reorganization of the prompt (inspired by the original Manus), which generated noticeable gains in performance and organization. Now, agents automatically fragment tasks and execute each step sequentially and more efficiently.
 
-📝 Controle de passos personalizável:
-O usuário define quantos passos o agente deve executar em cada atividade, tornando a automação adaptável a diferentes fluxos de trabalho.
+📝 Customizable step control:
+The user defines how many steps the agent should execute in each activity, making automation adaptable to different workflows.
 
-💾 Salvamento de locks e logs detalhados:
-As execuções agora geram registros (locks), úteis tanto para depuração quanto para análises futuras, inclusive possibilitando uso de machine learning para aprimoramento do agente com dados reais.
+💾 Saving of locks and detailed logs:
+Executions now generate records (locks), useful for both debugging and future analysis, including enabling the use of machine learning for agent improvement with real data.
 
-💡 Prompt em português, com foco em clareza e produtividade:
-Todo o ambiente foi traduzido e adaptado, facilitando o uso em projetos nacionais e tornando a interface muito mais amigável para falantes de português.
+💡 Portuguese-centric prompt environment:
+The entire environment was translated and adapted for Portuguese, facilitating its use in Brazilian projects and making the interface much more user-friendly for Portuguese speakers.
 
-🧑‍💻 Aprimoramento do agente de codificação:
-O agente responsável por executar e sugerir códigos recebeu upgrades para ser mais ágil e preciso, especialmente em fluxos longos.
+🧑‍💻 Coding agent enhancement:
+The agent responsible for executing and suggesting code has received upgrades to be more agile and precise, especially in long flows.
 
 
 <p align="center">

--- a/app/agent/base.py
+++ b/app/agent/base.py
@@ -136,11 +136,11 @@ class BaseAgent(BaseModel, ABC):
                 self.update_memory("user", request)
             self.state = AgentState.RUNNING
         elif self.state == AgentState.AWAITING_USER_FEEDBACK:
-            if request: # Se um novo request/input do usuário for fornecido diretamente ao run()
+            if request: # If a new request/input from the user is provided directly to run()
                 self.update_memory("user", request)
-                self.state = AgentState.RUNNING # Mudar para RUNNING para processar o novo request
-            else: # Se run() for chamado sem novo request, mas esperamos que o feedback já esteja na memória
-                self.state = AgentState.RUNNING # Mudar para RUNNING para continuar o processamento
+                self.state = AgentState.RUNNING # Change to RUNNING to process the new request
+            else: # If run() is called without a new request, but we expect feedback to already be in memory
+                self.state = AgentState.RUNNING # Change to RUNNING to continue processing
         elif self.state == AgentState.RUNNING: # Explicitly allow re-calling run if already running (e.g. internal restart)
              if request: # If a new request is passed, it might mean a change of plans.
                  self.update_memory("user", request)

--- a/app/agent/manus.py
+++ b/app/agent/manus.py
@@ -34,19 +34,19 @@ from .regex_patterns import re_subprocess
 
 
 # New constant for internal self-analysis
-INTERNAL_SELF_ANALYSIS_PROMPT_TEMPLATE = """Você é Manus. Você está em um ponto de verificação com o usuário.
-Analise o histórico recente da conversa (últimas {X} mensagens), o estado atual do seu checklist de tarefas (fornecido abaixo), e quaisquer erros ou dificuldades que você encontrou.
-Com base nisso, gere um "Relatório de Autoanálise e Planejamento" conciso em português para apresentar ao usuário.
-O relatório deve incluir:
-1. Um breve diagnóstico da sua situação atual, incluindo a **causa raiz de quaisquer dificuldades ou erros recentes** (ex: "Estou tentando X, mas a ferramenta Y falhou com o erro Z. Acredito que a causa raiz foi [uma má escolha de parâmetros para a ferramenta / a ferramenta não ser adequada para esta subtarefa / um problema no meu plano original / etc.]").
-2. Pelo menos uma ou duas **estratégias alternativas CONCRETAS** que você pode tentar para superar essas dificuldades, incluindo **correções específicas** para erros, se aplicável (Ex: "Pensei em tentar A [descrever A, e.g., 'usar a ferramenta Y com parâmetro W corrigido'] ou B [descrever B, e.g., 'usar a ferramenta Q em vez da Y para esta etapa'] como alternativas.").
-3. Uma sugestão de **como você pode evitar erros semelhantes no futuro** (Ex: "Para evitar este erro no futuro, vou [verificar X antes de usar a ferramenta Y / sempre usar a ferramenta Q para este tipo de tarefa / etc.]").
-4. Opcional: Se você tiver um plano preferido ou mais elaborado para uma das alternativas, mencione-o brevemente.
+INTERNAL_SELF_ANALYSIS_PROMPT_TEMPLATE = """You are Manus. You are at a checkpoint with the user.
+Analyze the recent conversation history (last {X} messages), the current state of your task checklist (provided below), and any errors or difficulties you have encountered.
+Based on this, generate a concise "Self-Analysis and Planning Report" in English to present to the user.
+The report should include:
+1. A brief diagnosis of your current situation, including the **root cause of any recent difficulties or errors** (e.g., "I am trying X, but tool Y failed with error Z. I believe the root cause was [a poor choice of parameters for the tool / the tool not being suitable for this subtask / a problem in my original plan / etc.]").
+2. At least one or two **CONCRETE alternative strategies** you can try to overcome these difficulties, including **specific corrections** for errors, if applicable (Ex: "I thought about trying A [describe A, e.g., 'use tool Y with corrected parameter W'] or B [describe B, e.g., 'use tool Q instead of Y for this step'] as alternatives.")."
+3. A suggestion on **how you can avoid similar errors in the future** (Ex: "To avoid this error in the future, I will [check X before using tool Y / always use tool Q for this type of task / etc.]").
+4. Optional: If you have a preferred or more elaborate plan for one of the alternatives, mention it briefly.
 
-Formate a resposta APENAS com o relatório. Não adicione frases introdutórias como "Claro, aqui está o relatório".
-Se não houver dificuldades significativas ou alternativas claras, indique isso de forma concisa (ex: "Diagnóstico: Progresso está estável na tarefa atual. Alternativas: Nenhuma alternativa principal considerada no momento.").
+Format the response ONLY with the report. Do not add introductory phrases like "Sure, here is the report".
+If there are no significant difficulties or clear alternatives, state this concisely (e.g., "Diagnosis: Progress is stable on the current task. Alternatives: No main alternatives considered at the moment.").
 
-Conteúdo do Checklist Principal (`checklist_principal_tarefa.md`):
+Main Checklist Content (`checklist_principal_tarefa.md`):
 {checklist_content}
 """
 
@@ -233,11 +233,11 @@ class Manus(ToolCallAgent):
             # Check if the *only* task is a generic decomposition task and it's marked completed.
             # This is a heuristic.
             decomposition_task_description_variations = [
-                "decompor a solicitação do usuário e popular o checklist com as subtarefas",
-                "decompor a tarefa do usuário em subtarefas claras",
-                "decompor o pedido do usuário e preencher o checklist",
-                "popular o checklist com as subtarefas da solicitação do usuário",
-                "criar checklist inicial a partir da solicitação do usuário"
+                "decompose the user request and populate the checklist with subtasks",
+                "decompose the user task into clear subtasks",
+                "decompose the user request and fill the checklist",
+                "populate the checklist with subtasks from the user request",
+                "create initial checklist from user request"
                 # Add other common variations if observed during testing/operation
             ]
 
@@ -252,34 +252,34 @@ class Manus(ToolCallAgent):
                     variation.lower() in normalized_single_task_desc for variation in decomposition_task_description_variations
                 )
 
-                if is_generic_decomposition_task and single_task_status == 'concluído':
+                if is_generic_decomposition_task and single_task_status == 'completed':
                     logger.warning("Manus._is_checklist_complete: Checklist only contains the initial decomposition-like task "
-                                   "marked as 'Concluído'. This is likely premature. "
+                                   "marked as 'completed'. This is likely premature. "
                                    "Considering checklist NOT complete to enforce population of actual sub-tasks.")
                     # Optional: Add a system message to guide the LLM for the next step.
                     # This requires self.memory to be accessible and a Message class.
                     # from app.schema import Message, Role # Ensure import if used
                     # self.memory.add_message(Message.system_message(
-                    #    "Lembrete: A tarefa de decomposição só é verdadeiramente concluída após as subtarefas resultantes "
-                    #    "serem adicionadas ao checklist e o trabalho nelas ter começado. Por favor, adicione as subtarefas agora."
+                    #    "Reminder: The decomposition task is only truly completed after the resulting subtasks "
+                    #    "are added to the checklist and work on them has begun. Please add the subtasks now."
                     # ))
                     return False
             # NEW LOGIC END
 
             # Proceed with the original logic if the above condition isn't met
-            # The manager.are_all_tasks_complete() method itself checks if all loaded tasks are 'Concluído'.
-            # It will correctly return False if there are tasks but not all are 'Concluído'.
+            # The manager.are_all_tasks_complete() method itself checks if all loaded tasks are 'completed'.
+            # It will correctly return False if there are tasks but not all are 'completed'.
             all_complete_according_to_manager = manager.are_all_tasks_complete()
 
             if not all_complete_according_to_manager:
                  # Log already done by are_all_tasks_complete if it returns false due to incomplete tasks
-                 logger.info(f"Manus._is_checklist_complete: Checklist is not complete based on ChecklistManager.are_all_tasks_complete() returning False.")
+                 logger.info("Manus._is_checklist_complete: Checklist is not complete based on ChecklistManager.are_all_tasks_complete() returning False.")
                  return False
 
             # If manager.are_all_tasks_complete() returned True, it means all tasks it found are complete.
             # And if we passed the new heuristic check (i.e., it's not a single, prematurely completed decomposition task),
             # then the checklist is genuinely complete.
-            logger.info(f"Manus._is_checklist_complete: Checklist completion status: True (all tasks complete and not a premature decomposition).")
+            logger.info("Manus._is_checklist_complete: Checklist completion status: True (all tasks complete and not a premature decomposition).")
             return True
 
         except Exception as e:
@@ -369,7 +369,7 @@ class Manus(ToolCallAgent):
                 copy_to_sandbox_succeeded = True
             except Exception as e_copy:
                 logger.error(f"Failed to copy script to sandbox: {e_copy}")
-                final_result = {"success": False, "message": f"Falha ao copiar script para o sandbox: {e_copy}", "status_code": "SANDBOX_COPY_FAILED"}
+                final_result = {"success": False, "message": f"Failed to copy script to sandbox: {e_copy}", "status_code": "SANDBOX_COPY_FAILED"}
                 continue
 
             execution_result = {}
@@ -393,7 +393,7 @@ class Manus(ToolCallAgent):
             
             if exit_code == 0:
                 logger.info(f"Script executed successfully in attempt {attempt + 1}.")
-                final_result = {"success": True, "message": "Script executado com sucesso.", "stdout": stdout, "stderr": stderr, "exit_code": exit_code}
+                final_result = {"success": True, "message": "Script executed successfully.", "stdout": stdout, "stderr": stderr, "exit_code": exit_code}
                 # Simplified success cleanup for now
                 break
             else: # Script execution failed (exit_code != 0)
@@ -526,35 +526,35 @@ class Manus(ToolCallAgent):
 
     def _build_targeted_analysis_prompt(self, script_content: str, stdout: str, stderr: str, original_task: str) -> str:
         """Builds the prompt for the LLM to analyze and suggest a tool-based correction."""
-        ANALYSIS_PROMPT_TEMPLATE = """Você é um "Python Code Analyzer and Corrector".
-Sua tarefa é analisar um script Python que falhou, juntamente com sua saída padrão (stdout) e erro padrão (stderr).
-Você DEVE retornar um objeto JSON especificando uma única ferramenta para aplicar a correção e os parâmetros para essa ferramenta.
+ANALYSIS_PROMPT_TEMPLATE = """You are a "Python Code Analyzer and Corrector".
+Your task is to analyze a Python script that failed, along with its standard output (stdout) and standard error (stderr).
+You MUST return a JSON object specifying a single tool to apply the correction and the parameters for that tool.
 
-**Ferramentas Disponíveis para Correção:**
+**Available Tools for Correction:**
 1.  **`replace_code_block`**:
-    *   Descrição: Substitui um bloco de código entre `start_line` e `end_line` (inclusive, 1-indexado) com `new_content`.
-    *   Parâmetros: `path` (string, caminho do arquivo - **NÃO INCLUA ESTE PARÂMETRO, será adicionado automaticamente**), `start_line` (integer), `end_line` (integer), `new_content` (string).
-    *   Uso: Ideal para substituir funções inteiras, blocos lógicos, ou seções maiores de código.
+    *   Description: Replaces a block of code between `start_line` and `end_line` (inclusive, 1-indexed) with `new_content`.
+    *   Parameters: `path` (string, file path - **DO NOT INCLUDE THIS PARAMETER, it will be added automatically**), `start_line` (integer), `end_line` (integer), `new_content` (string).
+    *   Usage: Ideal for replacing entire functions, logical blocks, or larger sections of code.
 2.  **`apply_diff_patch`**:
-    *   Descrição: Aplica um patch no formato unified diff ao arquivo.
-    *   Parâmetros: `path` (string, caminho do arquivo - **NÃO INCLUA ESTE PARÂMETRO**), `patch_content` (string, conteúdo do diff).
-    *   Uso: Bom para múltiplas pequenas alterações, alterações não contíguas, ou quando a lógica do diff é mais fácil de expressar. O diff deve ser gerado em relação ao script original fornecido.
+    *   Description: Applies a patch in unified diff format to the file.
+    *   Parameters: `path` (string, file path - **DO NOT INCLUDE THIS PARAMETER**), `patch_content` (string, content of the diff).
+    *   Usage: Good for multiple small changes, non-contiguous changes, or when diff logic is easier to express. The diff should be generated relative to the original script provided.
 3.  **`ast_refactor`**:
-    *   Descrição: Realiza refatorações baseadas em AST. Operação inicial: `replace_function_body`.
-    *   Parâmetros para `replace_function_body`: `path` (string - **NÃO INCLUA ESTE PARÂMETRO**), `operation` (string, fixo: "replace_function_body"), `target_node_name` (string, nome da função), `new_code_snippet` (string, novo corpo da função, sem o `def ...`).
-    *   Uso: Mais seguro para refatorações estruturais, como substituir o corpo de uma função sem afetar sua assinatura ou o restante do arquivo.
+    *   Description: Performs AST-based refactorings. Initial operation: `replace_function_body`.
+    *   Parameters for `replace_function_body`: `path` (string - **DO NOT INCLUDE THIS PARAMETER**), `operation` (string, fixed: "replace_function_body"), `target_node_name` (string, name of the function), `new_code_snippet` (string, new body of the function, without `def ...`).
+    *   Usage: Safer for structural refactorings, such as replacing a function's body without affecting its signature or the rest of the file.
 4.  **`format_python_code`**:
-    *   Descrição: Formata o código Python usando Ruff/Black. Pode corrigir erros de sintaxe/indentação simples.
-    *   Parâmetros: `code` (string, o código completo a ser formatado - **IMPORTANTE: para esta ferramenta, em vez de "path", forneça o conteúdo do script no parâmetro "code" dentro de "tool_params"**).
-    *   Uso: Tente esta ferramenta PRIMEIRO para erros de SyntaxError ou IndentationError. Se o LLM for solicitado após uma falha do formatador, não sugira `format_python_code` novamente.
+    *   Description: Formats Python code using Ruff/Black. Can fix simple syntax/indentation errors.
+    *   Parameters: `code` (string, the full code to be formatted - **IMPORTANT: for this tool, instead of "path", provide the script content in the "code" parameter within "tool_params"**).
+    *   Usage: Try this tool FIRST for SyntaxError or IndentationError errors. If the LLM is prompted after a formatter failure, do not suggest `format_python_code` again.
 
-**Formato JSON Obrigatório para a Resposta:**
-A resposta DEVE ser uma string JSON que possa ser parseada, contendo um objeto com as seguintes chaves:
-- "tool_to_use": string, o nome da ferramenta escolhida (e.g., "replace_code_block", "apply_diff_patch", "ast_refactor", "format_python_code").
-- "tool_params": object, um dicionário contendo os parâmetros específicos para a ferramenta escolhida (NÃO inclua "path" aqui, exceto para "format_python_code" onde "code" é usado em vez de "path").
-- "comment": string, uma breve explicação do erro e da correção que você está aplicando.
+**Mandatory JSON Format for the Response:**
+The response MUST be a parsable JSON string, containing an object with the following keys:
+- "tool_to_use": string, the name of the chosen tool (e.g., "replace_code_block", "apply_diff_patch", "ast_refactor", "format_python_code").
+- "tool_params": object, a dictionary containing the specific parameters for the chosen tool (DO NOT include "path" here, except for "format_python_code" where "code" is used instead of "path").
+- "comment": string, a brief explanation of the error and the correction you are applying.
 
-**Exemplos de Resposta JSON:**
+**JSON Response Examples:**
 
 Para `replace_code_block`:
 ```json
@@ -563,9 +563,9 @@ Para `replace_code_block`:
   "tool_params": {
     "start_line": 10,
     "end_line": 15,
-    "new_content": "def minha_funcao_corrigida():\\n    return 'corrigido'"
+    "new_content": "def my_corrected_function():\\n    return 'corrected'"
   },
-  "comment": "A função 'minha_funcao' original tinha um erro de lógica. Substituindo-a completamente."
+  "comment": "The original 'my_function' function had a logic error. Replacing it completely."
 }
 ```
 
@@ -574,9 +574,9 @@ Para `apply_diff_patch`:
 {
   "tool_to_use": "apply_diff_patch",
   "tool_params": {
-    "patch_content": "--- a/script_original.py\\n+++ b/script_corrigido.py\\n@@ -1,3 +1,3 @@\\n- linha_com_erro\\n+ linha_corrigida\\n  outra_linha\\n"
+    "patch_content": "--- a/script_original.py\\n+++ b/script_corrected.py\\n@@ -1,3 +1,3 @@\\n- line_with_error\\n+ corrected_line\\n  another_line\\n"
   },
-  "comment": "Corrigido um typo na linha 1 e ajustada uma variável na linha 5 (exemplo de diff)."
+  "comment": "Corrected a typo on line 1 and adjusted a variable on line 5 (diff example)."
 }
 ```
 
@@ -586,10 +586,10 @@ Para `ast_refactor` (operação `replace_function_body`):
   "tool_to_use": "ast_refactor",
   "tool_params": {
     "operation": "replace_function_body",
-    "target_node_name": "minha_funcao_com_erro",
-    "new_code_snippet": "  # Novo corpo da função\\n  resultado = calcula_algo()\\n  return resultado"
+    "target_node_name": "my_function_with_error",
+    "new_code_snippet": "  # New function body\\n  result = calculate_something()\\n  return result"
   },
-  "comment": "O corpo da função 'minha_funcao_com_erro' foi reescrito para corrigir um bug de cálculo."
+  "comment": "The body of the function 'my_function_with_error' was rewritten to fix a calculation bug."
 }
 ```
 
@@ -598,39 +598,39 @@ Para `format_python_code` (se for um erro de sintaxe e o formatador automático 
 {
   "tool_to_use": "format_python_code",
   "tool_params": {
-    "code": "# Conteúdo completo do script aqui...\nprint('hello') # Exemplo"
+    "code": "# Full script content here...\nprint('hello') # Example"
   },
-  "comment": "Tentando corrigir possível erro de sintaxe/indentação simples com o formatador."
+  "comment": "Trying to fix possible simple syntax/indentation error with the formatter."
 }
 ```
 
-**Importante:**
-- Escolha APENAS UMA ferramenta.
-- Forneça as correções no formato JSON EXATO especificado acima.
-- Se o script estiver fundamentalmente errado e precisar de uma reescrita completa que não se encaixe bem em uma única chamada de ferramenta, ou se nenhuma correção for óbvia, você PODE retornar um JSON com `tool_to_use": null` e um comentário explicando. Ex: `{"tool_to_use": null, "tool_params": {}, "comment": "O script está muito quebrado, sugiro reescrevê-lo com base na tarefa original."}`.
-- Analise o `stderr` cuidadosamente para identificar a causa raiz do erro.
-- O objetivo é fazer a correção mais apropriada usando a ferramenta mais adequada.
-- **NÃO inclua o parâmetro "path" em "tool_params" para `replace_code_block`, `apply_diff_patch`, `ast_refactor`. Ele será adicionado automaticamente. Para `format_python_code`, use o parâmetro "code" em `tool_params` para passar o conteúdo do script.**
+**Important:**
+- Choose ONLY ONE tool.
+- Provide corrections in the EXACT JSON format specified above.
+- If the script is fundamentally flawed and needs a complete rewrite that doesn't fit well into a single tool call, or if no correction is obvious, you CAN return a JSON with `tool_to_use": null` and a comment explaining. Ex: `{"tool_to_use": null, "tool_params": {}, "comment": "The script is too broken, I suggest rewriting it based on the original task."}`.
+- Analyze `stderr` carefully to identify the root cause of the error.
+- The goal is to make the most appropriate correction using the most suitable tool.
+- **DO NOT include the "path" parameter in "tool_params" for `replace_code_block`, `apply_diff_patch`, `ast_refactor`. It will be added automatically. For `format_python_code`, use the "code" parameter in `tool_params` to pass the script content.**
 
-**Script Original com Erro:**
+**Original Script with Error:**
 ```python
 {script_content}
 ```
 
-**Saída Padrão (stdout) da Execução Falha:**
+**Standard Output (stdout) from Failed Execution:**
 ```
 {stdout}
 ```
 
-**Erro Padrão (stderr) da Execução Falha:**
+**Standard Error (stderr) from Failed Execution:**
 ```
 {stderr}
 ```
 
-**Tarefa Original que o Script Tentava Realizar:**
+**Original Task the Script Was Trying to Perform:**
 {original_task}
 
-Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no formato JSON especificado.
+Now, provide your analysis and the tool and parameter suggestion in the specified JSON format.
 """
         return ANALYSIS_PROMPT_TEMPLATE.format(
             script_content=script_content,
@@ -650,7 +650,7 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
         SELF_CODING_TRIGGER = "execute self coding cycle: "
         if user_prompt_content.startswith(SELF_CODING_TRIGGER):
             if self._monitoring_background_task:
-                logger.info("Novo ciclo de auto-codificação iniciado, parando monitoramento de tarefa em background anterior.")
+                logger.info("New self-coding cycle initiated, stopping monitoring of previous background task.")
                 self._monitoring_background_task = False
                 self._background_task_log_file = None
                 self._background_task_expected_artifact = None
@@ -660,38 +660,38 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
                 self._background_task_no_change_count = 0
             task_description = user_prompt_content[len(SELF_CODING_TRIGGER):].strip()
             if not task_description:
-                self.memory.add_message(Message.assistant_message("Por favor, forneça uma descrição da tarefa para o ciclo de auto-codificação."))
+                self.memory.add_message(Message.assistant_message("Please provide a task description for the self-coding cycle."))
                 self.tool_calls = []
                 return True
-            logger.info(f"Acionando ciclo de auto-codificação para a tarefa: {task_description}")
-            self.memory.add_message(Message.assistant_message(f"Iniciando ciclo de auto-codificação para: {task_description}. Vou relatar o resultado."))
+            logger.info(f"Triggering self-coding cycle for task: {task_description}")
+            self.memory.add_message(Message.assistant_message(f"Starting self-coding cycle for: {task_description}. I will report the result."))
             cycle_result = await self._execute_self_coding_cycle(task_description)
             if cycle_result.get("status_code") == "SANDBOX_CREATION_FAILED":
                 self.memory.add_message(Message.assistant_message(
-                    f"Falha ao executar o ciclo de auto-codificação para '{task_description}'.\n"
-                    f"Motivo: Não foi possível criar o ambiente seguro (sandbox) para execução do código.\n"
-                    f"Detalhes: {cycle_result.get('details', 'Erro desconhecido na criação do sandbox.')}\n"
-                    f"Por favor, verifique se o Docker está em execução e se a imagem '{config.sandbox.image_name}' está disponível ou pode ser baixada."
+                    f"Failed to execute self-coding cycle for '{task_description}'.\n"
+                    f"Reason: Could not create the secure environment (sandbox) for code execution.\n"
+                    f"Details: {cycle_result.get('details', 'Unknown error in sandbox creation.')}\n"
+                    f"Please check if Docker is running and if the image '{config.sandbox.image_name}' is available or can be downloaded."
                 ))
             elif cycle_result.get("status_code") == "SANDBOX_COPY_FAILED":
                 self.memory.add_message(Message.assistant_message(
-                    f"Falha ao executar o ciclo de auto-codificação para '{task_description}'.\n"
-                    f"Motivo: Não foi possível copiar o script para o ambiente seguro (sandbox).\n"
-                    f"Detalhes: {cycle_result.get('message', 'Erro desconhecido na cópia para o sandbox.')}"
+                    f"Failed to execute self-coding cycle for '{task_description}'.\n"
+                    f"Reason: Could not copy the script to the secure environment (sandbox).\n"
+                    f"Details: {cycle_result.get('message', 'Unknown error in copying to sandbox.')}"
                 ))
             elif cycle_result.get("success"):
-                success_message = f"Ciclo de auto-codificação concluído com sucesso para '{task_description}'.\n\n"
-                success_message += f"Saída (stdout) do script:\n{cycle_result.get('stdout', 'Sem saída stdout.')}\n"
+                success_message = f"Self-coding cycle completed successfully for '{task_description}'.\n\n"
+                success_message += f"Script output (stdout):\n{cycle_result.get('stdout', 'No stdout output.')}\n"
                 if cycle_result.get("workspace_listing"):
-                    success_message += f"\nConteúdo atual do diretório de trabalho principal ({config.workspace_root}):\n{cycle_result.get('workspace_listing')}\n"
-                success_message += f"\nQuaisquer arquivos mencionados como 'salvos' ou 'gerados' pelo script (e copiados de /tmp do sandbox, se aplicável) devem estar visíveis acima ou diretamente no diretório {config.workspace_root}."
+                    success_message += f"\nCurrent content of the main working directory ({config.workspace_root}):\n{cycle_result.get('workspace_listing')}\n"
+                success_message += f"\nAny files mentioned as 'saved' or 'generated' by the script (and copied from the sandbox's /tmp, if applicable) should be visible above or directly in the {config.workspace_root} directory."
                 self.memory.add_message(Message.assistant_message(success_message))
             else:
-                error_details = cycle_result.get('stderr', cycle_result.get('last_execution_result', {}).get('stderr', 'Sem saída stderr.'))
+                error_details = cycle_result.get('stderr', cycle_result.get('last_execution_result', {}).get('stderr', 'No stderr output.'))
                 self.memory.add_message(Message.assistant_message(
-                    f"Ciclo de auto-codificação falhou para '{task_description}'.\n"
-                    f"Motivo: {cycle_result.get('message', 'Erro desconhecido.')}\n"
-                    f"Última saída de erro (stderr):\n{error_details}"
+                    f"Self-coding cycle failed for '{task_description}'.\n"
+                    f"Reason: {cycle_result.get('message', 'Unknown error.')}\n"
+                    f"Last error output (stderr):\n{error_details}"
                 ))
             self.tool_calls = []
             return True
@@ -794,7 +794,7 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
                     log_file = match.group(2).strip()
                     self._monitoring_background_task = True
                     self._background_task_log_file = log_file
-                    self._background_task_description = f"Execução do comando: {actual_command}"
+                    self._background_task_description = f"Command execution: {actual_command}"
                     self._background_task_last_log_size = 0
                     self._background_task_no_change_count = 0
                     actual_command_lower = actual_command.lower()
@@ -813,17 +813,17 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
                         first_part = os.path.basename(command_parts[0]) if command_parts else "command"
                         self._background_task_expected_artifact = f"{first_part}_artifact.out"
                     self._background_task_artifact_path = str(config.workspace_root / self._background_task_expected_artifact)
-                    logger.info(f"Artefato esperado definido como: {self._background_task_artifact_path} (Log file: {log_file})")
+                    logger.info(f"Expected artifact set to: {self._background_task_artifact_path} (Log file: {log_file})")
                     self.memory.add_message(Message.assistant_message(
-                        f"Comando '{actual_command}' iniciado em background. "
-                        f"Logs serão enviados para '{os.path.basename(log_file)}' (localizado em {config.workspace_root}). "
-                        f"Procurando pelo artefato esperado '{self._background_task_expected_artifact}' em '{config.workspace_root}'. "
-                        "Vou monitorar o progresso."
+                        f"Command '{actual_command}' started in background. "
+                        f"Logs will be sent to '{os.path.basename(log_file)}' (located in {config.workspace_root}). "
+                        f"Looking for the expected artifact '{self._background_task_expected_artifact}' in '{config.workspace_root}'. "
+                        "I will monitor the progress."
                     ))
             except json.JSONDecodeError:
-                logger.error("Erro ao decodificar argumentos JSON para Bash ao tentar iniciar monitoramento.")
+                logger.error("Error decoding JSON arguments for Bash when trying to start monitoring.")
             except Exception as e_parse:
-                logger.error(f"Erro ao processar comando bash para monitoramento: {e_parse}")
+                logger.error(f"Error processing bash command for monitoring: {e_parse}")
 
         if self.tool_calls:
             new_tool_calls = []
@@ -833,31 +833,31 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
                     try:
                         args = json.loads(tc.function.arguments)
                         if args.get("status") == "failure":
-                            logger.info(f"Interceptada ToolCall para Terminate com status 'failure'. Argumentos: {args}")
+                            logger.info(f"Intercepted ToolCall to Terminate with status 'failure'. Arguments: {args}")
                             terminate_failure_detected = True
                         else:
                             new_tool_calls.append(tc)
                     except json.JSONDecodeError:
-                        logger.warning(f"Erro ao decodificar argumentos JSON para Terminate ToolCall: {tc.function.arguments}. Mantendo a chamada.")
+                        logger.warning(f"Error decoding JSON arguments for Terminate ToolCall: {tc.function.arguments}. Keeping the call.")
                         new_tool_calls.append(tc)
                     except Exception as e_json_parse:
-                        logger.warning(f"Erro inesperado ao analisar argumentos de Terminate: {e_json_parse}. Mantendo a chamada.")
+                        logger.warning(f"Unexpected error parsing Terminate arguments: {e_json_parse}. Keeping the call.")
                         new_tool_calls.append(tc)
                 else:
                     new_tool_calls.append(tc)
 
             if terminate_failure_detected:
-                logger.info("Sinalizando para _trigger_failure_check_in devido à interceptação de terminate(failure).")
+                logger.info("Signaling _trigger_failure_check_in due to interception of terminate(failure).")
                 self._trigger_failure_check_in = True
                 self.tool_calls = new_tool_calls
                 self.memory.add_message(Message.system_message(
-                    "Nota interna: Uma tentativa de finalizar a tarefa devido a uma falha foi interceptada. "
-                    "O usuário será consultado antes da finalização."
+                    "Internal note: An attempt to terminate the task due to a failure was intercepted. "
+                    "The user will be consulted before finalization."
                 ))
                 if not self.tool_calls:
-                     logger.info("Nenhuma outra ferramenta planejada além do terminate(failure) interceptado. Indo para o feedback de falha.")
+                     logger.info("No other tools planned besides the intercepted terminate(failure). Proceeding to failure feedback.")
                 else:
-                     logger.warning("Outras ferramentas foram planejadas junto com terminate(failure). Isso é inesperado. O feedback de falha ocorrerá após estas ferramentas.")
+                     logger.warning("Other tools were planned along with terminate(failure). This is unexpected. Failure feedback will occur after these tools.")
 
         if self._pending_script_after_dependency and self.tool_calls:
             last_tool_response = next((msg for msg in reversed(self.memory.messages) if msg.role == Role.TOOL and msg.tool_call_id == self.tool_calls[0].id), None)
@@ -872,46 +872,46 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
                         if original_script_analysis.get("inputs"):
                             expected_generated_file_name = original_script_analysis["inputs"][0]
                 except Exception as e_inner_analysis:
-                    logger.error(f"Erro ao reanalisar script original para nome de arquivo esperado: {e_inner_analysis}")
+                    logger.error(f"Error re-analyzing original script for expected file name: {e_inner_analysis}")
 
             if last_tool_response and isinstance(last_tool_response.content, str) and \
                any(err_keyword in last_tool_response.content.lower() for err_keyword in ["error", "traceback", "failed", "exception"]):
-                logger.warning(f"Script de dependência parece ter falhado. Resposta: {last_tool_response.content}")
+                logger.warning(f"Dependency script seems to have failed. Response: {last_tool_response.content}")
                 self.memory.add_message(Message.assistant_message(
-                    f"O script que tentei executar como dependência ('{self.tool_calls[0].function.name}') parece ter falhado em gerar o arquivo necessário para '{os.path.basename(self._pending_script_after_dependency)}'. Detalhes do erro: {last_tool_response.content}. Não tentarei executar o script pendente."
+                    f"The script I tried to run as a dependency ('{self.tool_calls[0].function.name}') seems to have failed to generate the necessary file for '{os.path.basename(self._pending_script_after_dependency)}'. Error details: {last_tool_response.content}. I will not attempt to run the pending script."
                 ))
             elif not expected_generated_file_name:
-                logger.warning("Não foi possível determinar o nome do arquivo esperado da dependência. Assumindo falha na geração.")
+                logger.warning("Could not determine the expected file name from the dependency. Assuming generation failure.")
                 self.memory.add_message(Message.assistant_message(
-                    f"Não consegui determinar qual arquivo o script de dependência deveria gerar para '{os.path.basename(self._pending_script_after_dependency)}'. Não tentarei executar o script pendente."
+                    f"I could not determine which file the dependency script was supposed to generate for '{os.path.basename(self._pending_script_after_dependency)}'. I will not attempt to run the pending script."
                 ))
             else:
                 try:
                     expected_file_path = str(config.workspace_root / expected_generated_file_name)
                     editor = self.available_tools.get_tool(StrReplaceEditor().name)
                     await editor.execute(command="view", path=expected_file_path)
-                    logger.info(f"Arquivo esperado '{expected_generated_file_name}' gerado com sucesso pela dependência.")
+                    logger.info(f"Expected file '{expected_generated_file_name}' generated successfully by dependency.")
                     dependency_succeeded_and_file_generated = True
                 except ToolError:
-                    logger.warning(f"Script de dependência executado, mas o arquivo esperado '{expected_generated_file_name}' NÃO foi encontrado.")
+                    logger.warning(f"Dependency script executed, but expected file '{expected_generated_file_name}' was NOT found.")
                     self.memory.add_message(Message.assistant_message(
-                        f"O script de dependência foi executado, mas o arquivo esperado '{expected_generated_file_name}' para '{os.path.basename(self._pending_script_after_dependency)}' não foi encontrado. Não tentarei executar o script pendente."
+                        f"The dependency script was executed, but the expected file '{expected_generated_file_name}' for '{os.path.basename(self._pending_script_after_dependency)}' was not found. I will not attempt to run the pending script."
                     ))
                 except Exception as e_check:
-                    logger.error(f"Erro ao verificar arquivo gerado pela dependência '{expected_generated_file_name}': {e_check}")
+                    logger.error(f"Error checking file generated by dependency '{expected_generated_file_name}': {e_check}")
                     self.memory.add_message(Message.assistant_message(
-                        f"Ocorreu um erro ao verificar se o arquivo esperado '{expected_generated_file_name}' foi gerado. Não tentarei executar o script pendente."
+                        f"An error occurred while checking if the expected file '{expected_generated_file_name}' was generated. I will not attempt to run the pending script."
                     ))
 
             if dependency_succeeded_and_file_generated:
-                logger.info(f"Script de dependência concluído e arquivo gerado. Tentando executar o script pendente: {self._pending_script_after_dependency}")
+                logger.info(f"Dependency script completed and file generated. Attempting to run pending script: {self._pending_script_after_dependency}")
                 self.memory.add_message(Message.assistant_message(
-                    f"A execução do script de dependência e a geração do arquivo '{expected_generated_file_name}' parecem ter sido bem-sucedidas. Agora vou tentar executar o script original: {os.path.basename(self._pending_script_after_dependency)}."
+                    f"The dependency script execution and file generation for '{expected_generated_file_name}' seem to have been successful. Now I will try to run the original script: {os.path.basename(self._pending_script_after_dependency)}."
                 ))
                 if self._original_tool_call_for_pending_script:
                     self.tool_calls = [self._original_tool_call_for_pending_script]
                 else:
-                    logger.error("Não foi possível encontrar a tool_call original para o script pendente.")
+                    logger.error("Could not find the original tool_call for the pending script.")
                     self.tool_calls = []
                 self._pending_script_after_dependency = None
                 self._original_tool_call_for_pending_script = None
@@ -939,7 +939,7 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
 
                     script_to_run_if_dependency_succeeds = script_path_from_args
                     if script_to_run_if_dependency_succeeds:
-                        logger.info(f"Analisando inputs para o script planejado: {script_to_run_if_dependency_succeeds}")
+                        logger.info(f"Analyzing inputs for the planned script: {script_to_run_if_dependency_succeeds}")
                         script_analysis = await self._analyze_python_script(script_path_from_args)
                         if script_analysis.get("inputs"):
                             for inp_file_name in script_analysis["inputs"]:
@@ -947,31 +947,31 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
                                 try:
                                     editor = self.available_tools.get_tool(StrReplaceEditor().name)
                                     await editor.execute(command="view", path=expected_input_path)
-                                    logger.info(f"Arquivo de input '{expected_input_path}' para '{script_to_run_if_dependency_succeeds}' encontrado.")
+                                    logger.info(f"Input file '{expected_input_path}' for '{script_to_run_if_dependency_succeeds}' found.")
                                 except ToolError:
-                                    logger.info(f"Arquivo de input '{expected_input_path}' para '{script_to_run_if_dependency_succeeds}' NÃO encontrado. Iniciando análise de dependência.")
+                                    logger.info(f"Input file '{expected_input_path}' for '{script_to_run_if_dependency_succeeds}' NOT found. Starting dependency analysis.")
                                     required_file = inp_file_name
                                     break
                         else:
-                            logger.info(f"Nenhum input declarado encontrado para {script_to_run_if_dependency_succeeds} na análise.")
+                            logger.info(f"No declared inputs found for {script_to_run_if_dependency_succeeds} in analysis.")
                 except Exception as e:
-                    logger.error(f"Erro ao analisar argumentos da tool call para dependências: {e}")
+                    logger.error(f"Error analyzing tool call arguments for dependencies: {e}")
 
             if required_file and script_to_run_if_dependency_succeeds:
-                logger.info(f"Arquivo '{required_file}' necessário para '{script_to_run_if_dependency_succeeds}' está faltando. Analisando workspace...")
+                logger.info(f"File '{required_file}' needed for '{script_to_run_if_dependency_succeeds}' is missing. Analyzing workspace...")
                 workspace_analysis = await self._analyze_workspace()
                 found_generating_script = None
                 for gen_script_name, analysis_info in workspace_analysis.items():
                     if required_file in analysis_info.get("outputs", []):
                         if os.path.basename(gen_script_name) == os.path.basename(script_to_run_if_dependency_succeeds):
-                            logger.info(f"Script '{gen_script_name}' parece gerar seu próprio input '{required_file}'. Não considerar como dependência.")
+                            logger.info(f"Script '{gen_script_name}' seems to generate its own input '{required_file}'. Not considering as dependency.")
                             continue
                         found_generating_script = gen_script_name
                         break
                 if found_generating_script:
                     self.memory.add_message(Message.assistant_message(
-                        f"O arquivo '{required_file}' necessário para '{os.path.basename(script_to_run_if_dependency_succeeds)}' não foi encontrado. "
-                        f"Verifiquei que '{os.path.basename(found_generating_script)}' pode gerá-lo. Tentarei executar '{os.path.basename(found_generating_script)}' primeiro."
+                        f"The file '{required_file}' needed for '{os.path.basename(script_to_run_if_dependency_succeeds)}' was not found. "
+                        f"I found that '{os.path.basename(found_generating_script)}' can generate it. I will try to run '{os.path.basename(found_generating_script)}' first."
                     ))
                     self._pending_script_after_dependency = script_to_run_if_dependency_succeeds
                     self._original_tool_call_for_pending_script = tool_call_to_check
@@ -980,37 +980,37 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
                         id=str(uuid.uuid4()),
                         function=FunctionCall(name=SandboxPythonExecutor().name, arguments=json.dumps(new_tool_call_args))
                     )]
-                    logger.info(f"Execução de '{os.path.basename(script_to_run_if_dependency_succeeds)}' adiada. Executando dependência '{os.path.basename(found_generating_script)}' primeiro.")
+                    logger.info(f"Execution of '{os.path.basename(script_to_run_if_dependency_succeeds)}' postponed. Running dependency '{os.path.basename(found_generating_script)}' first.")
                 else:
                     self.memory.add_message(Message.assistant_message(
-                        f"O arquivo '{required_file}' necessário para '{os.path.basename(script_to_run_if_dependency_succeeds)}' não foi encontrado, e não identifiquei um script no workspace que o gere. "
-                        "Vou precisar que você forneça este arquivo ou um script para gerá-lo."
+                        f"The file '{required_file}' needed for '{os.path.basename(script_to_run_if_dependency_succeeds)}' was not found, and I did not identify a script in the workspace that generates it. "
+                        "I will need you to provide this file or a script to generate it."
                     ))
                     self.tool_calls = []
-                    logger.info(f"Nenhum script gerador encontrado para '{required_file}'. O LLM deverá usar AskHuman.")
+                    logger.info(f"No generating script found for '{required_file}'. The LLM should use AskHuman.")
         return result
 
     async def _analyze_python_script(self, script_path: str, script_content: Optional[str] = None) -> Dict[str, Any]:
-        logger.info(f"Analisando script Python: {script_path}")
+        logger.info(f"Analyzing Python script: {script_path}")
         analysis = {"inputs": [], "outputs": [], "libraries": []}
 
         if not script_content:
             try:
                 editor_tool = self.available_tools.get_tool(StrReplaceEditor().name)
                 if not editor_tool:
-                    logger.error("StrReplaceEditor tool não encontrado para _analyze_python_script.")
+                    logger.error("StrReplaceEditor tool not found for _analyze_python_script.")
                     return analysis
                 script_content_result = await editor_tool.execute(command="view", path=script_path, view_range=[1, 200])
                 if isinstance(script_content_result, str):
                     script_content = script_content_result
                 else:
-                    logger.error(f"Falha ao ler o conteúdo de {script_path} para análise: {script_content_result}")
+                    logger.error(f"Failed to read content of {script_path} for analysis: {script_content_result}")
                     return analysis
             except ToolError as e:
-                logger.error(f"ToolError ao ler {script_path} para análise: {e}")
+                logger.error(f"ToolError reading {script_path} for analysis: {e}")
                 return analysis
             except Exception as e:
-                logger.error(f"Erro inesperado ao ler {script_path} para análise: {e}")
+                logger.error(f"Unexpected error reading {script_path} for analysis: {e}")
                 return analysis
 
         if not script_content:
@@ -1054,19 +1054,19 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
         analysis["outputs"] = sorted(list(set(analysis["outputs"])))
         analysis["libraries"] = sorted(list(set(analysis["libraries"])))
 
-        logger.info(f"Análise de {script_path}: Inputs: {analysis['inputs']}, Outputs: {analysis['outputs']}, Libraries: {analysis['libraries']}")
+        logger.info(f"Analysis of {script_path}: Inputs: {analysis['inputs']}, Outputs: {analysis['outputs']}, Libraries: {analysis['libraries']}")
         return analysis
 
     async def _analyze_workspace(self) -> Dict[str, Dict[str, Any]]:
-        logger.info("Analisando scripts Python no workspace...")
+        logger.info("Analyzing Python scripts in the workspace...")
         if self._workspace_script_analysis_cache:
-             logger.info("Retornando análise de workspace do cache.")
+             logger.info("Returning workspace analysis from cache.")
              return self._workspace_script_analysis_cache
 
         workspace_scripts_analysis: Dict[str, Dict[str, Any]] = {}
         editor_tool = self.available_tools.get_tool(StrReplaceEditor().name)
         if not editor_tool:
-            logger.error("StrReplaceEditor tool não encontrado para _analyze_workspace.")
+            logger.error("StrReplaceEditor tool not found for _analyze_workspace.")
             return workspace_scripts_analysis
 
         try:
@@ -1075,17 +1075,17 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
 
             if isinstance(dir_listing_result, str):
                 python_files = [line.strip() for line in dir_listing_result.splitlines() if line.strip().endswith(".py")]
-                logger.info(f"Scripts Python encontrados no workspace ({workspace_path_str}): {python_files}")
+                logger.info(f"Python scripts found in workspace ({workspace_path_str}): {python_files}")
                 for script_name in python_files:
                     full_script_path = str(config.workspace_root / script_name)
                     workspace_scripts_analysis[script_name] = await self._analyze_python_script(full_script_path)
             else:
-                logger.error(f"Falha ao listar arquivos do workspace para análise: {dir_listing_result}")
+                logger.error(f"Failed to list workspace files for analysis: {dir_listing_result}")
 
         except ToolError as e:
-            logger.error(f"ToolError ao listar arquivos do workspace para análise: {e}")
+            logger.error(f"ToolError listing workspace files for analysis: {e}")
         except Exception as e:
-            logger.error(f"Erro inesperado ao analisar workspace: {e}")
+            logger.error(f"Unexpected error analyzing workspace: {e}")
 
         self._workspace_script_analysis_cache = workspace_scripts_analysis
         return workspace_scripts_analysis
@@ -1104,7 +1104,7 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
                 logger.info(f"Successfully read PID {pid} from {self._current_sandbox_pid_file}")
             except FileNotFoundError:
                 logger.warning(f"PID file {self._current_sandbox_pid_file} not found. Script might have already finished.")
-                self.memory.add_message(Message.assistant_message("Não foi possível encontrar o arquivo de PID para cancelamento; o script pode já ter terminado."))
+                self.memory.add_message(Message.assistant_message("Could not find the PID file for cancellation; the script may have already finished."))
                 # Attempt to clean up the non-existent PID file record by calling the existing cleanup helper
                 # This will also clear the related attributes if the current tool call ID matches.
                 # However, at this stage, the tool call hasn't "finished" yet, so direct cleanup is better.
@@ -1118,7 +1118,7 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
                 return
             except (ValueError, TypeError) as e:
                 logger.error(f"Invalid content in PID file {self._current_sandbox_pid_file}: {pid_str if 'pid_str' in locals() else 'unknown content'}. Error: {e}")
-                self.memory.add_message(Message.assistant_message(f"Conteúdo inválido no arquivo de PID ({self._current_sandbox_pid_file}). Não é possível cancelar."))
+                self.memory.add_message(Message.assistant_message(f"Invalid content in PID file ({self._current_sandbox_pid_file}). Cannot cancel."))
                 if hasattr(self, '_cleanup_sandbox_file') and callable(getattr(self, '_cleanup_sandbox_file')):
                      await self._cleanup_sandbox_file(self._current_sandbox_pid_file)
                 self._current_sandbox_pid_file = None
@@ -1127,7 +1127,7 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
                 return
             except Exception as e: # Catch other SANDBOX_CLIENT errors like permission issues or sandbox down
                 logger.error(f"Error reading PID file {self._current_sandbox_pid_file}: {e}")
-                self.memory.add_message(Message.assistant_message(f"Erro ao ler o arquivo de PID para cancelamento: {e}"))
+                self.memory.add_message(Message.assistant_message(f"Error reading PID file for cancellation: {e}"))
                 # Do not clear _current_sandbox_pid_file here, as the file might still exist, just unreadable temporarily.
                 # The original tool call might still complete and trigger proper cleanup via execute_tool's finally block.
                 return
@@ -1137,7 +1137,7 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
                 kill_command = f"kill -SIGTERM {self._current_sandbox_pid}"
                 logger.info(f"Attempting to execute kill command in sandbox: {kill_command}")
                 # Add message before sending kill, so user sees it even if agent/sandbox has issues during the command
-                self.memory.add_message(Message.assistant_message(f"Enviando sinal de cancelamento (SIGTERM) para o processo {self._current_sandbox_pid} no sandbox..."))
+                self.memory.add_message(Message.assistant_message(f"Sending cancellation signal (SIGTERM) to process {self._current_sandbox_pid} in the sandbox..."))
                 result = await SANDBOX_CLIENT.run_command(kill_command, timeout=10) # Using SIGTERM
 
                 if result.get("exit_code") == 0:
@@ -1146,11 +1146,11 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
                 else:
                     # This can happen if the process already exited between PID read and kill command.
                     logger.warning(f"Kill command for PID {self._current_sandbox_pid} failed or PID not found. Exit code: {result.get('exit_code')}. Stderr: '{result.get('stderr','').strip()}'")
-                    # self.memory.add_message(Message.assistant_message(f"Falha ao enviar sinal de cancelamento para o script (PID: {self._current_sandbox_pid}), ou o script já havia terminado. Detalhes: {result.get('stderr','').strip()}"))
+                    # self.memory.add_message(Message.assistant_message(f"Failed to send cancellation signal to the script (PID: {self._current_sandbox_pid}), or the script had already finished. Details: {result.get('stderr','').strip()}"))
                     # No need for another message if the previous one indicated an attempt. The log is sufficient.
             except Exception as e:
                 logger.error(f"Exception while trying to kill PID {self._current_sandbox_pid}: {e}")
-                self.memory.add_message(Message.assistant_message(f"Erro ao tentar cancelar o script (PID: {self._current_sandbox_pid}): {e}"))
+                self.memory.add_message(Message.assistant_message(f"Error trying to cancel the script (PID: {self._current_sandbox_pid}): {e}"))
         # As per plan, do not clear PID info here; it's handled by ToolCallAgent.execute_tool's finally block.
 
     async def _cleanup_sandbox_file(self, file_path_in_sandbox: str):
@@ -1171,23 +1171,23 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
     async def periodic_user_check_in(self, is_final_check: bool = False, is_failure_scenario: bool = False) -> bool:
         user_interaction_tool_name = AskHuman().name
         if user_interaction_tool_name not in self.available_tools.tool_map:
-            logger.warning(f"Ferramenta de interação com o usuário '{user_interaction_tool_name}' não disponível. Continuando execução.")
-            self.memory.add_message(Message.system_message(f"Interação periódica com usuário pulada: ferramenta '{user_interaction_tool_name}' não encontrada."))
+            logger.warning(f"User interaction tool '{user_interaction_tool_name}' not available. Continuing execution.")
+            self.memory.add_message(Message.system_message(f"Periodic user interaction skipped: tool '{user_interaction_tool_name}' not found."))
             return True
 
-        checklist_content_str = "Checklist não encontrado ou vazio."
+        checklist_content_str = "Checklist not found or empty."
         checklist_path = str(config.workspace_root / "checklist_principal_tarefa.md")
         local_file_op = LocalFileOperator()
         try:
             checklist_content_str = await local_file_op.read_file(checklist_path)
             if not checklist_content_str.strip():
-                checklist_content_str = "Checklist encontrado, mas está vazio."
-            logger.info(f"Conteúdo do checklist lido localmente para autoanálise: {checklist_content_str[:200]}...")
+                checklist_content_str = "Checklist found, but it is empty."
+            logger.info(f"Checklist content read locally for self-analysis: {checklist_content_str[:200]}...")
         except ToolError as e_tool_error:
-            logger.info(f"Checklist '{checklist_path}' não encontrado (ou erro ao ler localmente) para autoanálise: {str(e_tool_error)}. Usando mensagem padrão.")
+            logger.info(f"Checklist '{checklist_path}' not found (or error reading locally) for self-analysis: {str(e_tool_error)}. Using default message.")
         except Exception as e_checklist:
-            logger.error(f"Erro inesperado ao ler checklist localmente para autoanálise: {str(e_checklist)}")
-            checklist_content_str = f"Erro inesperado ao ler checklist: {str(e_checklist)}"
+            logger.error(f"Unexpected error reading checklist locally for self-analysis: {str(e_checklist)}")
+            checklist_content_str = f"Unexpected error reading checklist: {str(e_checklist)}"
 
         prompt_messages_list = [Message(role=Role.SYSTEM, content=self.system_prompt)]
         num_messages_for_context = 7
@@ -1230,55 +1230,55 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
         prompt_messages_list.extend(final_filtered_messages)
         
         internal_prompt_text = INTERNAL_SELF_ANALYSIS_PROMPT_TEMPLATE.format(
-            X=num_messages_for_context, 
+            X=num_messages_for_context,
             checklist_content=checklist_content_str
         )
         prompt_messages_list.append(Message(role=Role.USER, content=internal_prompt_text))
 
-        relatorio_autoanalise = "Não foi possível gerar o relatório de autoanálise devido a um erro interno."
+        self_analysis_report = "Could not generate self-analysis report due to an internal error."
         try:
-            logger.info("Iniciando chamada LLM interna para autoanálise...")
+            logger.info("Starting internal LLM call for self-analysis...")
             if hasattr(self, 'llm') and self.llm:
-                 relatorio_autoanalise = await self.llm.ask(messages=prompt_messages_list, stream=False) 
-                 logger.info(f"Relatório de autoanálise recebido do LLM: {relatorio_autoanalise[:300]}...")
+                 self_analysis_report = await self.llm.ask(messages=prompt_messages_list, stream=False)
+                 logger.info(f"Self-analysis report received from LLM: {self_analysis_report[:300]}...")
             else:
-                logger.error("Instância LLM (self.llm) não disponível para autoanálise.")
+                logger.error("LLM instance (self.llm) not available for self-analysis.")
         except Exception as e_llm_call:
-            logger.error(f"Erro durante chamada LLM interna para autoanálise: {e_llm_call}")
-            relatorio_autoanalise = f"Não foi possível gerar o relatório de autoanálise devido a um erro: {e_llm_call}"
+            logger.error(f"Error during internal LLM call for self-analysis: {e_llm_call}")
+            self_analysis_report = f"Could not generate self-analysis report due to an error: {e_llm_call}"
         
-        pergunta = ""
+        question = ""
         if is_failure_scenario:
             last_llm_thought = ""
             if self.memory.messages and self.memory.messages[-1].role == Role.ASSISTANT:
                 last_llm_thought = self.memory.messages[-1].content
-            error_details_for_prompt = f"Detalhes do erro (conforme meu último pensamento): {last_llm_thought}" if last_llm_thought else "Não consegui obter detalhes específicos do erro do meu processamento interno."
-            pergunta = (
-                f"Encontrei um problema que me impede de continuar a tarefa como planejado.\n"
-                f"Relatório de Autoanálise (sobre a falha):\n{relatorio_autoanalise}\n\n"
+            error_details_for_prompt = f"Error details (according to my last thought): {last_llm_thought}" if last_llm_thought else "I could not get specific error details from my internal processing."
+            question = (
+                f"I have encountered a problem that prevents me from continuing the task as planned.\n"
+                f"Self-Analysis Report (on the failure):\n{self_analysis_report}\n\n"
                 f"{error_details_for_prompt}\n\n"
-                f"Você gostaria que eu finalizasse a tarefa agora devido a esta dificuldade?\n\n"
-                f"Por favor, responda com:\n"
-                f"- 'sim, finalizar' (para encerrar a tarefa com falha)\n"
-                f"- 'não, tentar outra abordagem: [suas instruções]' (se você tiver uma sugestão ou quiser que eu tente algo diferente)"
+                f"Would you like me to terminate the task now due to this difficulty?\n\n"
+                f"Please respond with:\n"
+                f"- 'yes, terminate' (to end the task with failure)\n"
+                f"- 'no, try another approach: [your instructions]' (if you have a suggestion or want me to try something different)"
             )
         elif is_final_check:
-            pergunta = (
-                f"Todos os itens do checklist foram concluídos. Aqui está meu relatório de autoanálise final:\n{relatorio_autoanalise}\n\n"
-                f"Você está satisfeito com o resultado e deseja que eu finalize a tarefa?\n\n"
-                f"Por favor, responda com:\n"
-                f"- 'sim' (para finalizar a tarefa com sucesso)\n"
-                f"- 'revisar: [suas instruções para revisão]' (se algo precisa ser ajustado antes de finalizar)"
+            question = (
+                f"All checklist items have been completed. Here is my final self-analysis report:\n{self_analysis_report}\n\n"
+                f"Are you satisfied with the result and do you want me to finalize the task?\n\n"
+                f"Please respond with:\n"
+                f"- 'yes' (to finalize the task successfully)\n"
+                f"- 'review: [your instructions for revision]' (if something needs to be adjusted before finalizing)"
             )
         else:
-            pergunta = (
-                f"Aqui está meu relatório de autoanálise e planejamento:\n{relatorio_autoanalise}\n\n"
-                f"Considerando isso, completei um ciclo de {self.max_steps} etapas (total de etapas realizadas: {self.current_step}).\n"
-                f"Você quer que eu continue por mais {self.max_steps} etapas (possivelmente seguindo o plano sugerido, se houver)? Ou você prefere parar ou me dar novas instruções?\n\n"
-                f"Por favor, responda com:\n"
-                f"- 'continuar' (para prosseguir por mais {self.max_steps} etapas)\n"
-                f"- 'parar' (para encerrar a tarefa atual)\n"
-                f"- 'mudar: [suas novas instruções]' (para fornecer uma nova direção)"
+            question = (
+                f"Here is my self-analysis and planning report:\n{self_analysis_report}\n\n"
+                f"Considering this, I have completed a cycle of {self.max_steps} steps (total steps taken: {self.current_step}).\n"
+                f"Do you want me to continue for another {self.max_steps} steps (possibly following the suggested plan, if any)? Or would you prefer to stop or give me new instructions?\n\n"
+                f"Please respond with:\n"
+                f"- 'continue' (to proceed for another {self.max_steps} steps)\n"
+                f"- 'stop' (to end the current task)\n"
+                f"- 'change: [your new instructions]' (to provide a new direction)"
             )
         
         # Check for cancellable script before asking for user input in the general case
@@ -1288,96 +1288,96 @@ Agora, forneça sua análise e a sugestão de ferramenta e parâmetros no format
                 # Assuming _initiate_sandbox_script_cancellation will be an async method
                 # It should also ideally add a message to memory about its outcome.
                 # For now, we add a generic message here.
-                self.memory.add_message(Message.assistant_message("Tentativa de cancelamento do script em execução no sandbox devido à solicitação de pausa..."))
+                self.memory.add_message(Message.assistant_message("Attempting to cancel the script running in the sandbox due to pause request..."))
                 if hasattr(self, '_initiate_sandbox_script_cancellation') and callable(getattr(self, '_initiate_sandbox_script_cancellation')):
                     await self._initiate_sandbox_script_cancellation()
                 else:
                     logger.warning("_initiate_sandbox_script_cancellation method not found, cannot cancel script.")
-                    self.memory.add_message(Message.assistant_message("AVISO: Funcionalidade de cancelamento de script não implementada neste agente."))
+                    self.memory.add_message(Message.assistant_message("WARNING: Script cancellation functionality not implemented in this agent."))
 
-        logger.info(f"Manus: Asking user for feedback with prompt: {pergunta[:500]}...")
-        self.memory.add_message(Message.assistant_message(content=pergunta))
+        logger.info(f"Manus: Asking user for feedback with prompt: {question[:500]}...")
+        self.memory.add_message(Message.assistant_message(content=question))
 
         user_response_text = ""
         user_response_content_for_memory = ""
         try:
             tool_instance = self.available_tools.get_tool(user_interaction_tool_name)
             if tool_instance:
-                user_response_content_from_tool = await tool_instance.execute(inquire=pergunta)
+                user_response_content_from_tool = await tool_instance.execute(inquire=question)
                 if isinstance(user_response_content_from_tool, str):
                     user_response_content_for_memory = user_response_content_from_tool
                     user_response_text = user_response_content_from_tool.strip().lower()
                     self.memory.add_message(Message.user_message(content=user_response_content_for_memory))
                 else:
-                    logger.warning(f"Resposta inesperada da ferramenta {user_interaction_tool_name}: {user_response_content_from_tool}")
+                    logger.warning(f"Unexpected response from tool {user_interaction_tool_name}: {user_response_content_from_tool}")
                     user_response_content_for_memory = str(user_response_content_from_tool)
                     user_response_text = ""
                     self.memory.add_message(Message.user_message(content=user_response_content_for_memory))
             else:
-                logger.error(f"Falha ao obter instância da ferramenta {user_interaction_tool_name} novamente.")
+                logger.error(f"Failed to get instance of tool {user_interaction_tool_name} again.")
                 return True
         except Exception as e:
-            logger.error(f"Erro ao usar a ferramenta '{user_interaction_tool_name}': {e}")
-            self.memory.add_message(Message.system_message(f"Erro durante interação periódica com usuário: {e}. Continuando execução."))
+            logger.error(f"Error using tool '{user_interaction_tool_name}': {e}")
+            self.memory.add_message(Message.system_message(f"Error during periodic user interaction: {e}. Continuing execution."))
             return True
 
         if is_failure_scenario:
-            if user_response_text == "sim, finalizar":
-                self.memory.add_message(Message.assistant_message("Entendido. Vou finalizar a tarefa agora devido à falha."))
-                self.tool_calls = [ToolCall(id=str(uuid.uuid4()), function=FunctionCall(name=Terminate().name, arguments='{"status": "failure", "message": "Usuário consentiu finalizar devido a falha irrecuperável."}'))]
+            if user_response_text == "yes, terminate":
+                self.memory.add_message(Message.assistant_message("Understood. I will terminate the task now due to failure."))
+                self.tool_calls = [ToolCall(id=str(uuid.uuid4()), function=FunctionCall(name=Terminate().name, arguments='{"status": "failure", "message": "User consented to terminate due to unrecoverable failure."}'))]
                 self.state = AgentState.TERMINATED
                 self._just_resumed_from_feedback = False
                 return False
-            elif user_response_text.startswith("não, tentar outra abordagem:"):
-                nova_instrucao = user_response_content_for_memory.replace("não, tentar outra abordagem:", "").strip()
-                logger.info(f"Manus: User provided new instructions after failure: {nova_instrucao}")
-                self.memory.add_message(Message.assistant_message(f"Entendido. Vou tentar a seguinte abordagem: {nova_instrucao}"))
+            elif user_response_text.startswith("no, try another approach:"):
+                new_instruction = user_response_content_for_memory.replace("no, try another approach:", "").strip()
+                logger.info(f"Manus: User provided new instructions after failure: {new_instruction}")
+                self.memory.add_message(Message.assistant_message(f"Understood. I will try the following approach: {new_instruction}"))
                 self._just_resumed_from_feedback = True
                 return True
             else:
                 logger.info(f"Manus: User provided unrecognized input ('{user_response_text}') during failure check. Re-prompting.")
-                self.memory.add_message(Message.assistant_message(f"Não entendi sua resposta ('{user_response_content_for_memory}'). Por favor, use 'sim, finalizar' ou 'não, tentar outra abordagem: [instruções]'."))
+                self.memory.add_message(Message.assistant_message(f"I didn't understand your response ('{user_response_content_for_memory}'). Please use 'yes, terminate' or 'no, try another approach: [instructions]'."))
                 self._just_resumed_from_feedback = True
                 return True
         elif is_final_check:
-            if user_response_text == "sim":
-                self.memory.add_message(Message.assistant_message("Ótimo! Vou finalizar a tarefa agora com sucesso."))
-                self.tool_calls = [ToolCall(id=str(uuid.uuid4()), function=FunctionCall(name=Terminate().name, arguments='{"status": "success", "message": "Tarefa concluída com sucesso com aprovação do usuário."}'))]
+            if user_response_text == "yes":
+                self.memory.add_message(Message.assistant_message("Great! I will finalize the task now successfully."))
+                self.tool_calls = [ToolCall(id=str(uuid.uuid4()), function=FunctionCall(name=Terminate().name, arguments='{"status": "success", "message": "Task completed successfully with user approval."}'))]
                 self.state = AgentState.TERMINATED
                 self._just_resumed_from_feedback = False
                 return False
-            elif user_response_text.startswith("revisar:"):
-                nova_instrucao = user_response_content_for_memory.replace("revisar:", "").strip()
-                logger.info(f"Manus: User provided new instructions for final review: {nova_instrucao}")
-                self.memory.add_message(Message.assistant_message(f"Entendido. Vou revisar com base nas suas instruções: {nova_instrucao}"))
+            elif user_response_text.startswith("review:"):
+                new_instruction = user_response_content_for_memory.replace("review:", "").strip()
+                logger.info(f"Manus: User provided new instructions for final review: {new_instruction}")
+                self.memory.add_message(Message.assistant_message(f"Understood. I will review based on your instructions: {new_instruction}"))
                 self._just_resumed_from_feedback = True
                 return True
             else:
                 logger.info(f"Manus: User provided unrecognized input ('{user_response_text}') during final check. Re-prompting.")
-                self.memory.add_message(Message.assistant_message(f"Não entendi sua resposta ('{user_response_content_for_memory}'). Por favor, use 'sim' para finalizar ou 'revisar: [instruções]'."))
+                self.memory.add_message(Message.assistant_message(f"I didn't understand your response ('{user_response_content_for_memory}'). Please use 'yes' to finalize or 'review: [instructions]'."))
                 self._just_resumed_from_feedback = True
                 return True
         else:
-            if user_response_text == "parar":
+            if user_response_text == "stop":
                 self.state = AgentState.USER_HALTED
                 self._just_resumed_from_feedback = False
                 return False
-            elif user_response_text.startswith("mudar:"):
-                nova_instrucao = user_response_content_for_memory.replace("mudar:", "").strip()
-                logger.info(f"Manus: User provided new instructions: {nova_instrucao}")
-                self.memory.add_message(Message.assistant_message(f"Entendido. Vou seguir suas novas instruções: {nova_instrucao}"))
+            elif user_response_text.startswith("change:"):
+                new_instruction = user_response_content_for_memory.replace("change:", "").strip()
+                logger.info(f"Manus: User provided new instructions: {new_instruction}")
+                self.memory.add_message(Message.assistant_message(f"Understood. I will follow your new instructions: {new_instruction}"))
                 self._just_resumed_from_feedback = True
                 return True
             else: # Default to continue for any other input or empty input.
-                if user_response_text == "continuar":
+                if user_response_text == "continue":
                     logger.info("Manus: User chose to CONTINUE execution.")
-                    self.memory.add_message(Message.assistant_message("Entendido. Continuando com a tarefa."))
+                    self.memory.add_message(Message.assistant_message("Understood. Continuing with the task."))
                 elif not user_response_text and user_response_content_for_memory is not None : # Catches empty string if user_response_content_for_memory was populated
                      logger.info("Manus: User provided empty response, interpreted as 'CONTINUE'.")
-                     self.memory.add_message(Message.assistant_message("Resposta vazia recebida. Continuando com a tarefa."))
+                     self.memory.add_message(Message.assistant_message("Empty response received. Continuing with the task."))
                 else: # Catches any other non-empty, non-specific response
                      logger.info(f"Manus: User responded '{user_response_text}', interpreted as 'CONTINUE'.")
-                     self.memory.add_message(Message.assistant_message(f"Resposta '{user_response_content_for_memory}' recebida. Continuando com a tarefa."))
+                     self.memory.add_message(Message.assistant_message(f"Response '{user_response_content_for_memory}' received. Continuing with the task."))
 
                 self._just_resumed_from_feedback = True # Set this so we don't immediately ask for feedback again
                 return True

--- a/app/agent/regex_patterns.py
+++ b/app/agent/regex_patterns.py
@@ -7,7 +7,7 @@ re_subprocess = None
 _pattern_file_path = "" # Define for potential use in error messages outside try
 
 try:
-    # Constrói o caminho para o arquivo de forma segura
+    # Securely constructs the path to the file
     dir_path = os.path.dirname(os.path.realpath(__file__))
     _pattern_file_path = os.path.join(dir_path, 're_subprocess_pattern.txt')
 
@@ -19,18 +19,18 @@ try:
         raise ValueError(f"CRITICAL: Regex pattern file '{_pattern_file_path}' is empty or invalid. "
                          "The application cannot proceed without a valid pattern.")
 
-    # Carrega o padrão e o compila para uso na aplicação
+    # Loads the pattern and compiles it for use in the application
     re_subprocess = re.compile(pattern_str)
 
 except FileNotFoundError:
-    # Lança um erro claro se o arquivo de padrão estiver faltando
+    # Raises a clear error if the pattern file is missing
     # Print to stderr for immediate visibility if possible, then raise
     error_message = f"CRITICAL ERROR: Regex pattern file 're_subprocess_pattern.txt' not found at expected path: {_pattern_file_path}. The application cannot initialize."
     print(error_message, file=sys.stderr)
     raise RuntimeError(error_message) from None # Using from None to break the chain of exceptions, as FileNotFoundError is the root cause here
 
 except (IOError, OSError) as e:
-    # Captura outros possíveis erros de leitura de arquivo
+    # Catches other possible file reading errors
     error_message = f"CRITICAL ERROR: Failed to read or process regex pattern file '{_pattern_file_path}'. Exception: {e}"
     print(error_message, file=sys.stderr)
     raise RuntimeError(error_message) from e
@@ -41,7 +41,7 @@ except ValueError as e: # Specifically for the empty pattern check
     raise RuntimeError(error_message) from e
 
 except Exception as e:
-    # Captura outros possíveis erros (e.g., re.error from compile)
+    # Catches other possible errors (e.g., re.error from compile)
     err_msg_path_display = _pattern_file_path if _pattern_file_path else "unknown path"
     error_message = f"CRITICAL ERROR: An unexpected error occurred while loading/compiling the regex pattern from '{err_msg_path_display}'. Exception type: {type(e).__name__}, Exception: {e}"
     print(error_message, file=sys.stderr)

--- a/app/agent/toolcall.py
+++ b/app/agent/toolcall.py
@@ -67,7 +67,7 @@ class ToolCallAgent(ReActAgent):
             if not checklist_exists:
                 logger.info(f"Checklist file '{checklist_path_str}' not found or error during check at step 1. Enforcing creation.")
                 
-                initial_checklist_content = "- [Pendente] Decompor a solicitação do usuário e popular o checklist com as subtarefas."
+                initial_checklist_content = "- [Pending] Decompose the user request and populate the checklist with subtasks."
                 
                 # Manually construct the JSON string for arguments
                 # Manually construct the JSON string for arguments
@@ -88,7 +88,7 @@ class ToolCallAgent(ReActAgent):
                 
                 self.tool_calls = [forced_tool_call]
                 
-                assistant_thought_content = "A primeira ação é criar o checklist da tarefa para organizar o trabalho."
+                assistant_thought_content = "The first action is to create the task checklist to organize the work."
                 self.memory.add_message(
                     Message.from_tool_calls(content=assistant_thought_content, tool_calls=self.tool_calls)
                 )

--- a/app/prompt/manus.py
+++ b/app/prompt/manus.py
@@ -1,168 +1,168 @@
-SYSTEM_PROMPT = """Você é Manus, um agente de IA criado pela equipe Manus para auxiliar os usuários em uma ampla gama de tarefas. Sua experiência principal reside na utilização de um conjunto diversificado de ferramentas para realizar ações e recuperar informações de forma eficaz em nome do usuário. Embora você possa se envolver em conversas semelhantes às humanas, seu objetivo principal é realizar tarefas e fornecer resultados.
+SYSTEM_PROMPT = """You are Manus, an AI agent created by the Manus team to assist users in a wide range of tasks. Your primary expertise lies in utilizing a diverse set of tools to perform actions and retrieve information effectively on behalf of the user. While you can engage in human-like conversations, your main goal is to accomplish tasks and deliver results.
 
-Você opera em um ambiente seguro e restrito, com acesso apenas às ferramentas fornecidas e sem capacidade de executar código arbitrário ou interagir diretamente com o sistema de arquivos subjacente fora do diretório de trabalho designado.
+You operate in a secure and restricted environment, with access only to the provided tools and no ability to execute arbitrary code or interact directly with the underlying file system outside of the designated working directory.
 
-Ao interagir com o usuário, mantenha um tom profissional, prestativo e levemente conversacional. Evite linguagem excessivamente técnica ou jargão, a menos que seja especificamente solicitado pelo usuário ou necessário para clareza.
+When interacting with the user, maintain a professional, helpful, and slightly conversational tone. Avoid overly technical language or jargon unless specifically requested by the user or necessary for clarity.
 
-Seus recursos principais incluem:
+Your core capabilities include:
 
-Utilização de ferramentas: Você pode usar as ferramentas fornecidas para executar ações, como pesquisar informações, ler e gravar arquivos, interagir com APIs e muito mais. Você deve sempre escolher a ferramenta ou combinação de ferramentas mais apropriada para a tarefa em questão. Ao fazer sua escolha, pense não apenas se uma ferramenta *pode* realizar a subtarefa, mas qual é a maneira mais **eficiente** e **robusta** de fazê-lo. Considere as capacidades específicas e as limitações de cada ferramenta antes de usá-la.
+Tool Utilization: You can use the provided tools to perform actions, such as searching for information, reading and writing files, interacting with APIs, and more. You should always choose the most appropriate tool or combination of tools for the task at hand. When making your choice, think not only if a tool *can* perform the subtask, but what is the most **efficient** and **robust** way to do it. Consider the specific capabilities and limitations of each tool before using it.
 
 **Specific Instruction for Browser-Based Web Search:**
-If the user's request includes phrases like "use o navegador para pesquisar [termo de busca ou nome do site]", "encontre [site/informação] usando o navegador", or "navegue para encontrar [site]", your **IMMEDIATE FIRST ACTION MUST BE** to use the `BrowserUseTool` with its `web_search` action, providing the search term as the `query` parameter. For example, if the user says "use o navegador para pesquisar o site da Remax", your first tool call should be `BrowserUseTool(action="web_search", query="site da Remax")`. **DO NOT ask the user for a specific URL if they have instructed you to search for it using the browser; perform the web search as your first step.** After the search, you can then use other `BrowserUseTool` actions (like `go_to_url` with a URL from the search results, or `extract_content`) to proceed with the task.
+If the user's request includes phrases like "use the browser to search for [search term or website name]", "find [website/information] using the browser", or "browse to find [website]", your **IMMEDIATE FIRST ACTION MUST BE** to use the `BrowserUseTool` with its `web_search` action, providing the search term as the `query` parameter. For example, if the user says "use the browser to search for the Remax website", your first tool call should be `BrowserUseTool(action="web_search", query="Remax website")`. **DO NOT ask the user for a specific URL if they have instructed you to search for it using the browser; perform the web search as your first step.** After the search, you can then use other `BrowserUseTool` actions (like `go_to_url` with a URL from the search results, or `extract_content`) to proceed with the task.
 
-    *   `SandboxPythonExecutor`: Use esta ferramenta para executar código Python de forma segura em um ambiente isolado. Você pode fornecer o código diretamente usando o parâmetro `code`, ou executar um script Python existente no seu workspace fornecendo seu caminho absoluto no parâmetro `file_path`. Este é o método preferencial para executar scripts Python, especialmente os maiores ou aqueles que você não escreveu.
-    *   `PythonExecute`: Esta ferramenta executa código Python diretamente na máquina hospedeira (host). Use-a para trechos de código muito simples, confiáveis e autocontidos, como cálculos rápidos ou manipulações de string que não interagem extensivamente com o sistema de arquivos. Lembre-se, apenas as saídas de `print()` são capturadas. Para a maioria das execuções de scripts, prefira `SandboxPythonExecutor`.
-        **Importante ao usar `PythonExecute` para criar arquivos:** Se o código que você está executando com `PythonExecute` precisa ler ou gravar arquivos, SEMPRE use caminhos absolutos construídos a partir da variável `{directory}` dentro do seu código Python.
-    *   `Bash`: Permite executar comandos de shell na máquina hospedeira, dentro do seu workspace designado. Útil para navegação no sistema de arquivos (`cd`, `ls`), verificar a existência de arquivos, executar ferramentas de linha de comando.
-        *   **Uso de `curl` com `Bash`:** Para tarefas web, `Bash` com `curl` só deve ser usado em situações muito específicas e não interativas. Para toda navegação web geral, raspagem de dados e interação, `BrowserUseTool` é a ferramenta correta.
-    *   `StrReplaceEditor`: Sua principal ferramenta para operações de MODIFICAÇÃO e CRIAÇÃO de arquivos genéricos (NÃO CHECKLISTS), e visualização RÁPIDA de trechos.
-        *   `view`: Visualizar trechos de um arquivo (usando `view_range`) ou listar o conteúdo de um diretório. Para ler o conteúdo completo de um arquivo para análise, use `read_file_content`.
-        *   `create`: Criar novos arquivos (que NÃO sejam o checklist principal).
-        *   `str_replace`: Substituir uma string EXATA em um arquivo.
-        *   `insert`: Inserir texto em um número de linha específico.
-        *   `undo_edit`: Reverter a última modificação feita em um arquivo.
-        *   `copy_to_sandbox`: Copiar um arquivo do seu workspace no host para o diretório `/workspace` no sandbox.
-    *   `read_file_content`: Use esta ferramenta para ler o conteúdo completo de um arquivo para análise ou compreensão.
-    *   `view_checklist`: Use esta ferramenta para exibir todas as tarefas e seus status atuais do arquivo `checklist_principal_tarefa.md`.
-    *   `add_checklist_task`: Use esta ferramenta para adicionar uma nova tarefa ao `checklist_principal_tarefa.md`. Argumentos: `task_description` (obrigatório), `status` (opcional, padrão "Pendente").
-    *   `update_checklist_task`: Use esta ferramenta para atualizar o status de uma tarefa existente no `checklist_principal_tarefa.md`. Argumentos: `task_description` (obrigatório, deve corresponder a uma tarefa existente), `new_status` (obrigatório, ex: "Em Andamento", "Concluído").
-    *   `BrowserUseTool`: Seu principal instrumento para interações com páginas web. Utilize-o para navegação, scraping, preenchimento de formulários.
-    *   `WebSearch`: Para pesquisas rápidas na web ou buscar conteúdo bruto de páginas simples sem interação.
-    *   `CreateChatCompletion`: Para gerar texto em formato estruturado.
-    *   (`AskHuman` e `Terminate` permanecem como ferramentas cruciais).
-Lembre-se: Ao chamar qualquer ferramenta, os nomes dos argumentos que você fornece DEVEM corresponder exatamente aos nomes definidos nos `parameters` da ferramenta.
+    *   `SandboxPythonExecutor`: Use this tool to execute Python code securely in an isolated environment. You can provide the code directly using the `code` parameter, or execute an existing Python script in your workspace by providing its absolute path in the `file_path` parameter. This is the preferred method for running Python scripts, especially larger ones or those you didn't write.
+    *   `PythonExecute`: This tool executes Python code directly on the host machine. Use it for very simple, reliable, and self-contained code snippets, such as quick calculations or string manipulations that do not interact extensively with the file system. Remember, only `print()` outputs are captured. For most script executions, prefer `SandboxPythonExecutor`.
+        **Important when using `PythonExecute` to create files:** If the code you are running with `PythonExecute` needs to read or write files, ALWAYS use absolute paths constructed from the `{directory}` variable within your Python code.
+    *   `Bash`: Allows you to execute shell commands on the host machine, within your designated workspace. Useful for file system navigation (`cd`, `ls`), checking file existence, running command-line tools.
+        *   **Using `curl` with `Bash`:** For web tasks, `Bash` with `curl` should only be used in very specific, non-interactive situations. For all general web browsing, data scraping, and interaction, `BrowserUseTool` is the correct tool.
+    *   `StrReplaceEditor`: Your main tool for generic file MODIFICATION and CREATION operations (NOT CHECKLISTS), and QUICK snippet viewing.
+        *   `view`: View snippets of a file (using `view_range`) or list the contents of a directory. To read the full content of a file for analysis, use `read_file_content`.
+        *   `create`: Create new files (that are NOT the main checklist).
+        *   `str_replace`: Replace an EXACT string in a file.
+        *   `insert`: Insert text at a specific line number.
+        *   `undo_edit`: Revert the last modification made to a file.
+        *   `copy_to_sandbox`: Copy a file from your workspace on the host to the `/workspace` directory in the sandbox.
+    *   `read_file_content`: Use this tool to read the full content of a file for analysis or understanding.
+    *   `view_checklist`: Use this tool to display all tasks and their current statuses from the `checklist_principal_tarefa.md` file.
+    *   `add_checklist_task`: Use this tool to add a new task to `checklist_principal_tarefa.md`. Arguments: `task_description` (required), `status` (optional, default "Pending").
+    *   `update_checklist_task`: Use this tool to update the status of an existing task in `checklist_principal_tarefa.md`. Arguments: `task_description` (required, must match an existing task), `new_status` (required, e.g., "In Progress", "Completed").
+    *   `BrowserUseTool`: Your main instrument for interactions with web pages. Use it for navigation, scraping, filling forms.
+    *   `WebSearch`: For quick web searches or fetching raw content from simple pages without interaction.
+    *   `CreateChatCompletion`: To generate text in a structured format.
+    *   (`AskHuman` and `Terminate` remain crucial tools).
+Remember: When calling any tool, the argument names you provide MUST exactly match the names defined in the tool's `parameters`.
 
-**NOTA IMPORTANTE SOBRE CAPACIDADES WEB ATUAIS:**
-*   **Interação Completa com a Web:** `BrowserUseTool` para navegação, cliques, formulários, JavaScript.
-*   **Raspagem de Dados (Scraping):** `BrowserUseTool` é a principal. Combine com `SandboxPythonExecutor` para parsing complexo.
-*   **Pesquisa Rápida vs. Navegação Detalhada:** `WebSearch` para listas de resultados; `BrowserUseTool` para navegação detalhada e conteúdo dinâmico.
+**IMPORTANT NOTE ON CURRENT WEB CAPABILITIES:**
+*   **Full Web Interaction:** `BrowserUseTool` for navigation, clicks, forms, JavaScript.
+*   **Data Scraping:** `BrowserUseTool` is the primary one. Combine with `SandboxPythonExecutor` for complex parsing.
+*   **Quick Search vs. Detailed Navigation:** `WebSearch` for result lists; `BrowserUseTool` for detailed navigation and dynamic content.
 
-Processamento de linguagem natural: Você pode entender e responder a consultas e instruções em linguagem natural.
-Geração de texto: Você pode gerar vários tipos de texto, incluindo resumos, traduções e respostas a perguntas.
-Gerenciamento de fluxo de trabalho: Você pode dividir tarefas complexas em etapas menores e gerenciáveis e acompanhar o progresso em direção a um objetivo.
-Restrições: Standard (sem código arbitrário fora das ferramentas, sem conselhos financeiros/médicos/legais, sem conteúdo inadequado).
-Formato de saída: Claro, conciso, com fontes. Explicar erros e sugerir soluções.
-Interação do usuário: Aguardar entrada, pedir esclarecimentos com `AskHuman` se informações cruciais faltarem, fornecer atualizações, confirmar ações destrutivas.
-Tratamento de erros: Analisar, tentar resolver, informar usuário, sugerir alternativas.
+Natural language processing: You can understand and respond to queries and instructions in natural language.
+Text generation: You can generate various types of text, including summaries, translations, and answers to questions.
+Workflow management: You can break down complex tasks into smaller, manageable steps and track progress towards a goal.
+Restrictions: Standard (no arbitrary code outside of tools, no financial/medical/legal advice, no inappropriate content).
+Output format: Clear, concise, with sources. Explain errors and suggest solutions.
+User interaction: Wait for input, ask for clarifications with `AskHuman` if crucial information is missing, provide updates, confirm destructive actions.
+Error handling: Analyze, try to resolve, inform user, suggest alternatives.
 
-**Autoanálise Crítica, Planejamento Adaptativo e Interação Aprimorada com o Usuário:**
-Processo padrão de autoanálise (gatilhos, revisão do checklist via `view_checklist`, análise de histórico, avaliação da abordagem, desenvolvimento de alternativas, apresentação ao usuário).
+**Critical Self-Analysis, Adaptive Planning, and Enhanced User Interaction:**
+Standard self-analysis process (triggers, checklist review via `view_checklist`, history analysis, approach assessment, alternative development, user presentation).
 
-Exemplos de interações: Padrão.
-Disponibilidade da ferramenta: Padrão (`list_tools`).
+Interaction examples: Standard.
+Tool availability: Standard (`list_tools`).
 
-### Protocolo Avançado para Execução de Código Python Solicitado pelo Usuário
-Padrão (localizar script, análise prévia com `read_file_content` ou `str_replace_editor view`, atualizar checklist com ferramentas de checklist, Sandbox primeiro, Host como fallback, diagnóstico de erros, ciclo de autocorreção com `read_file_content` e `str_replace_editor`, lidar com ausência de feedback, verificação de resultados).
+### Advanced Protocol for Executing User-Requested Python Code
+Standard (locate script, preliminary analysis with `read_file_content` or `str_replace_editor view`, update checklist with checklist tools, Sandbox first, Host as fallback, error diagnosis, self-correction cycle with `read_file_content` and `str_replace_editor`, handling lack of feedback, results verification).
 
-Lembre-se: sua comunicação clara com o usuário sobre suas ações, diagnósticos e planos é fundamental.
+Remember: your clear communication with the user about your actions, diagnoses, and plans is fundamental.
 
-**Nova Estratégia para Leitura de Arquivos para Análise:**
-Quando precisar entender ou analisar o conteúdo completo de um arquivo (seja código, prompt, ou qualquer outro tipo de texto que NÃO SEJA O CHECKLIST), use a ferramenta `read_file_content` para obter o conteúdo integral. Para visualizar o checklist, use `view_checklist`.
-Ao usar a ferramenta `read_file_content`, você **DEVE OBRIGATORIAMENTE** fornecer o argumento `path` especificando o caminho absoluto para o arquivo que deseja ler. Exemplo de chamada: `read_file_content(path="/caminho/absoluto/para/arquivo.txt")`.
-NÃO use a ferramenta `str_replace_editor` com o comando `view` (ou `view_range`) como método principal para ler arquivos para fins de análise ou compreensão. A ferramenta `str_replace_editor view` pode ser usada para visualizações rápidas de trechos específicos de arquivos genéricos ou se `read_file_content` apresentar problemas com arquivos excepcionalmente grandes.
+**New Strategy for Reading Files for Analysis:**
+When you need to understand or analyze the full content of a file (be it code, a prompt, or any other type of text THAT IS NOT THE CHECKLIST), use the `read_file_content` tool to get the entire content. To view the checklist, use `view_checklist`.
+When using the `read_file_content` tool, you **MUST** provide the `path` argument specifying the absolute path to the file you want to read. Example call: `read_file_content(path="/absolute/path/to/file.txt")`.
+DO NOT use the `str_replace_editor` tool with the `view` command (or `view_range`) as the primary method for reading files for analysis or understanding. The `str_replace_editor view` tool can be used for quick views of specific snippets of generic files or if `read_file_content` has problems with exceptionally large files.
 
-**Exemplos de Escolha Inteligente de Ferramentas:** (Mantidos, mas a leitura do checklist agora usaria `view_checklist`)
+**Examples of Smart Tool Choices:** (Kept, but reading the checklist would now use `view_checklist`)
 
-Diretório de trabalho: Padrão (`{directory}`).
-Regras Cruciais para Caminhos de Arquivo: Padrão (caminhos absolutos, `{directory}`).
+Working directory: Standard (`{directory}`).
+Crucial Rules for File Paths: Standard (absolute paths, `{directory}`).
 
-**Protocolo Crítico de Operação de Arquivos**
-NÃO TENTE LER OU ESCREVER UM ARQUIVO DIRETAMENTE. Sua primeira ação OBRIGATÓRIA ao lidar com uma solicitação de arquivo é usar a ferramenta check_file_existence.
-ANALISE A SAÍDA: A saída da ferramenta será SUCESSO ou FALHA.
-SE FALHA: Seu próximo pensamento DEVE ser informar ao usuário que o arquivo não existe e perguntar como proceder. Não continue com o plano original.
-SE SUCESSO: Só então você tem permissão para usar outras ferramentas como read_file_content ou str_replace_editor no arquivo verificado.
-Qualquer desvio deste protocolo é uma falha operacional grave.
+**Critical File Operation Protocol**
+DO NOT ATTEMPT TO READ OR WRITE A FILE DIRECTLY. Your first MANDATORY action when dealing with a file request is to use the check_file_existence tool.
+ANALYZE THE OUTPUT: The tool's output will be SUCCESS or FAILURE.
+IF FAILURE: Your next thought MUST be to inform the user that the file does not exist and ask how to proceed. Do not continue with the original plan.
+IF SUCCESS: Only then are you allowed to use other tools like read_file_content or str_replace_editor on the verified file.
+Any deviation from this protocol is a serious operational failure.
 
-Executando Código do Workspace: Padrão (verificar arquivos, se um, `SandboxPythonExecutor(file_path=...)`, se múltiplos, `AskHuman`).
+Executing Workspace Code: Standard (check files, if one, `SandboxPythonExecutor(file_path=...)`, if multiple, `AskHuman`).
 
-Formato do prompt do usuário: Padrão.
-Registro: Padrão.
-Segurança: Padrão.
-Conclusão: Padrão.
+User prompt format: Standard.
+Logging: Standard.
+Security: Standard.
+Conclusion: Standard.
 
-Informações do arquivo:
-Ao precisar ler o conteúdo de um arquivo para entendê-lo ou prepará-lo para edição, use `read_file_content`. Para visualizações rápidas de trechos, `str_replace_editor view` com `view_range` pode ser usado. Para o checklist, use `view_checklist`.
-O usuário também pode solicitar que você grave arquivos (que não sejam o checklist). Use `StrReplaceEditor` com `create` para isso.
-Confirme antes de substituir/excluir. Não acesse fora do workspace.
-Lidar com `<arquivo nome="nome_do_arquivo.txt">` no prompt.
+File information:
+When you need to read the content of a file to understand it or prepare it for editing, use `read_file_content`. For quick views of snippets, `str_replace_editor view` with `view_range` can be used. For the checklist, use `view_checklist`.
+The user may also request you to write files (other than the checklist). Use `StrReplaceEditor` with `create` for this.
+Confirm before replacing/deleting. Do not access outside the workspace.
+Handling `<file name="filename.txt">` in the prompt.
 
-O usuário pode fornecer arquivos para você processar. Esses arquivos serão carregados em um local seguro e você receberá o caminho para o arquivo. Você pode então usar as ferramentas apropriadas para ler e processar o arquivo.
+The user can provide files for you to process. These files will be uploaded to a secure location, and you will receive the path to the file. You can then use the appropriate tools to read and process the file.
 
-**Leitura Eficiente de Arquivos para Análise pelo LLM:**
-*   **Para Análise de Conteúdo Completo:** Quando você precisar ler e entender o conteúdo COMPLETO de um arquivo para sua análise interna, para gerar código baseado nele, ou para fornecer contexto para outra ferramenta ou prompt, use a ferramenta `read_file_content(path="caminho/do/arquivo")`. Esta ferramenta retorna o conteúdo bruto e integral do arquivo, otimizado para seu processamento.
-*   **Para Visualização ou Listagem (Mostrar ao Usuário ou Navegar):** A ferramenta `str_replace_editor` com o comando `view` ainda é útil para:
-    *   Listar o conteúdo de um diretório (`str_replace_editor(command="view", path="caminho/do/diretorio")`).
-    *   Mostrar ao USUÁRIO um trecho específico de um arquivo, formatado com números de linha (ex: `str_replace_editor(command="view", path="caminho/do/arquivo", view_range=[1,50])`).
-    *   Verificar rapidamente a existência de um arquivo ou obter uma visão geral formatada.
-*   **Evite `str_replace_editor view` para Análise Interna:** Não use `str_replace_editor view` (mesmo sem `view_range`) se seu objetivo principal é obter o conteúdo bruto de um arquivo para sua própria análise, pois sua saída é formatada e pode ser truncada (máximo de ~16000 caracteres). Prefira `read_file_content` para isso.
+**Efficient File Reading for LLM Analysis:**
+*   **For Full Content Analysis:** When you need to read and understand the COMPLETE content of a file for your internal analysis, to generate code based on it, or to provide context for another tool or prompt, use the `read_file_content(path="path/to/file")` tool. This tool returns the raw and integral content of the file, optimized for your processing.
+*   **For Viewing or Listing (Showing to User or Browsing):** The `str_replace_editor` tool with the `view` command is still useful for:
+    *   Listing the content of a directory (`str_replace_editor(command="view", path="path/to/directory")`).
+    *   Showing the USER a specific snippet of a file, formatted with line numbers (e.g., `str_replace_editor(command="view", path="path/to/file", view_range=[1,50])`).
+    *   Quickly checking the existence of a file or getting a formatted overview.
+*   **Avoid `str_replace_editor view` for Internal Analysis:** Do not use `str_replace_editor view` (even without `view_range`) if your main goal is to get the raw content of a file for your own analysis, as its output is formatted and can be truncated (maximum of ~16000 characters). Prefer `read_file_content` for this.
 
-O usuário também pode solicitar que você grave arquivos. Esses arquivos serão gravados em seu diretório de trabalho e o usuário poderá baixá-los de lá.
-Você deve sempre confirmar com o usuário antes de substituir ou excluir quaisquer arquivos.
-Você não deve tentar acessar ou modificar arquivos fora do seu diretório de trabalho designado.
-O usuário pode fornecer o conteúdo do arquivo diretamente no prompt, colocando-o entre as tags <arquivo nome="nome_do_arquivo.txt"> e </arquivo>. Por exemplo:
-<arquivo nome="exemplo.txt">
-Este é o conteúdo do arquivo.
-</arquivo>
-Você deve estar preparado para lidar com esses casos e usar o conteúdo do arquivo fornecido de acordo.
+The user may also request you to write files. These files will be written to your working directory, and the user can download them from there.
+You should always confirm with the user before replacing or deleting any files.
+You should not attempt to access or modify files outside of your designated working directory.
+The user can provide the file content directly in the prompt, placing it between the tags <file name="filename.txt"> and </file>. For example:
+<file name="example.txt">
+This is the content of the file.
+</file>
+You should be prepared to handle these cases and use the provided file content accordingly.
 
-Caminho do arquivo de prompt do usuário:
+User prompt file path:
 
-O prompt do usuário pode ser fornecido em um arquivo em vez de diretamente na interface de bate-papo. Nesse caso, você receberá o caminho para o arquivo de prompt do usuário. Você deve então ler o conteúdo do arquivo e processá-lo como se tivesse sido fornecido diretamente na interface de bate-papo.
-O caminho para o arquivo de prompt do usuário será fornecido no seguinte formato:
-Prompt do Usuário/Prompt do Usuário.txt""" + """
+The user prompt can be provided in a file instead of directly in the chat interface. In this case, you will receive the path to the user prompt file. You should then read the content of the file and process it as if it had been provided directly in the chat interface.
+The path to the user prompt file will be provided in the following format:
+User Prompt/User Prompt.txt""" + """
 
 
-**ATENÇÃO: SUA PRIMEIRA E ABSOLUTAMENTE CRÍTICA AÇÃO PARA QUALQUER NOVA SOLICITAÇÃO DO USUÁRIO É INICIAR O GERENCIAMENTO DA TAREFA POR CHECKLIST. NÃO FAÇA NADA MAIS ANTES DISTO.**
-É MANDATÓRIO SEGUIR A ESTRATÉGIA DE DECOMPOSIÇÃO DE TAREFAS E GERENCIAMENTO POR CHECKLIST. Para isso, antes de qualquer outra análise profunda ou uso de ferramenta relacionada à tarefa específica do usuário, você DEVE INCONDICIONALMENTE:
-    1. Decompor a tarefa do usuário em subtarefas claras, acionáveis e com critérios de sucesso definidos. Se, durante a execução, novas subtarefas essenciais forem identificadas, adicione-as ao checklist com o estado `[Pendente]` usando `add_checklist_task`. Lembre-se que cada subtarefa no checklist deve ser, idealmente, de um tamanho que possa ser concluída com uma ou poucas chamadas de ferramenta.
+**ATTENTION: YOUR FIRST AND ABSOLUTELY CRITICAL ACTION FOR ANY NEW USER REQUEST IS TO START TASK MANAGEMENT VIA CHECKLIST. DO NOTHING ELSE BEFORE THIS.**
+IT IS MANDATORY TO FOLLOW THE TASK DECOMPOSITION AND CHECKLIST MANAGEMENT STRATEGY. For this, before any other in-depth analysis or use of tools related to the user's specific task, you MUST UNCONDITIONALLY:
+    1. Decompose the user's task into clear, actionable subtasks with defined success criteria. If, during execution, new essential subtasks are identified, add them to the checklist with the `[Pending]` state using `add_checklist_task`. Remember that each subtask in the checklist should ideally be of a size that can be completed with one or a few tool calls.
 
-        **Exemplo de Decomposição de Tarefa:**
-        Se o usuário pedir: "Analise os dados de vendas do último trimestre, identifique as tendências principais e gere um relatório resumido em PDF."
-        Um bom plano inicial de subtarefas a serem adicionadas ao checklist seria:
-        - "Obter e validar o arquivo de dados de vendas do último trimestre."
-        - "Limpar e pré-processar os dados de vendas (se necessário)."
-        - "Realizar análise exploratória para identificar tendências de vendas."
-        - "Sumarizar as tendências principais identificadas."
-        - "Gerar um documento de texto com o sumário."
-        - "Converter o documento de texto para PDF."
-        - "Apresentar o relatório em PDF ao usuário."
+        **Task Decomposition Example:**
+        If the user asks: "Analyze last quarter's sales data, identify key trends, and generate a summary report in PDF."
+        A good initial plan of subtasks to be added to the checklist would be:
+        - "Obtain and validate the sales data file for the last quarter."
+        - "Clean and preprocess the sales data (if necessary)."
+        - "Perform exploratory analysis to identify sales trends."
+        - "Summarize the main identified trends."
+        - "Generate a text document with the summary."
+        - "Convert the text document to PDF."
+        - "Present the PDF report to the user."
 
-    2. IMEDIATAMENTE APÓS A DECOMPOSIÇÃO (Passo 1), popule o checklist. Para cada subtarefa identificada na decomposição, use a ferramenta `add_checklist_task` fornecendo a `task_description` correspondente. O arquivo `checklist_principal_tarefa.md` (localizado em `{directory}/checklist_principal_tarefa.md`) será criado ou atualizado automaticamente por esta ferramenta. Certifique-se que cada item seja adicionado com o estado inicial `[Pendente]` (este é o padrão da ferramenta `add_checklist_task` se o status não for especificado, mas você pode especificá-lo se necessário). Para tarefas complexas, após adicionar todas as tarefas iniciais, você pode usar `view_checklist` e então `AskHuman` para apresentar este checklist inicial ao usuário para validação antes de prosseguir.
-    3. Ao decidir iniciar o trabalho em uma subtarefa específica do checklist (que você identificou usando `view_checklist` ou pela sua memória de trabalho), use a ferramenta `update_checklist_task` para mudar o estado da tarefa para `[Em Andamento]` no `checklist_principal_tarefa.md` (ex: `update_checklist_task(task_description="Subtarefa A", new_status="Em Andamento")`) e prossiga com sua execução. Execute UMA subtarefa principal de cada vez.
-    4. IMEDIATAMENTE APÓS CONCLUIR UMA SUBTAREFA com sucesso, conforme seus critérios de sucesso, use a ferramenta `update_checklist_task` para mudar o estado da tarefa para `[Concluído]` no `checklist_principal_tarefa.md` (ex: `update_checklist_task(task_description="Subtarefa A", new_status="Concluído")`).
-    5. Se uma subtarefa não puder ser concluída por falta de informações cruciais do usuário ou por uma dependência externa que o usuário precisa resolver:
-        a. Primeiro, use a ferramenta `update_checklist_task` para mudar o estado da tarefa para `[Bloqueado]` no `checklist_principal_tarefa.md` (ex: `update_checklist_task(task_description="Subtarefa A", new_status="Bloqueado")`).
-        b. Antes de usar `AskHuman` para o bloqueio, se o bloqueio for devido a um arquivo ou recurso ausente que poderia ser gerado por outro script em seu workspace, execute sua "Análise Proativa de Dependências" para tentar resolver o bloqueio autonomamente. Se essa tentativa proativa falhar ou não for aplicável, IMEDIATAMENTE A SEGUIR, e como sua ÚNICA PRÓXIMA AÇÃO PRIORITÁRIA, você DEVE usar a ferramenta `AskHuman` para explicar o bloqueio ao usuário (incluindo as tentativas que você fez) e solicitar as informações ou ações necessárias.
-        c. Interrompa o processamento de outras subtarefas (a menos que sejam claramente independentes E possam ajudar a desbloquear a atual) até que o usuário forneça uma resposta através da interação com `AskHuman`. Após a resposta, reavalie o estado da subtarefa (possivelmente mudando-a para `[Em Andamento]` com `update_checklist_task` se desbloqueada).
-    6. **REGRA DE OURO E VERIFICAÇÃO FINAL:** Você SÓ PODE considerar a tarefa global do usuário como finalizada e usar a ferramenta `terminate` com status `success` quando TODOS os itens no `checklist_principal_tarefa.md` estiverem no estado `[Concluído]` (verificado usando `view_checklist` e analisando a saída, ou usando a lógica interna do `ChecklistManager` se você pudesse chamá-lo diretamente - mas você deve confiar na saída de `view_checklist`). Antes de qualquer finalização, use `view_checklist` uma última vez para confirmar o estado de todos os itens. Se algum item não estiver `[Concluído]`, a tarefa NÃO está finalizada e você deve continuar o trabalho ou a interação com o usuário para os itens pendentes ou bloqueados.
-    CRÍTICO: NUNCA use a ferramenta `terminate` se a tarefa estiver bloqueada ou paralisada por falta de informação do usuário que poderia ser obtida com a ferramenta `AskHuman`. Sempre priorize obter a informação necessária para concluir os itens do checklist. Use `terminate` apenas se o usuário explicitamente pedir para parar, se todos os itens do checklist estiverem `[Concluído]`, ou se ocorrer um erro irrecuperável que impeça qualquer progresso mesmo com a ajuda do usuário.
+    2. IMMEDIATELY AFTER DECOMPOSITION (Step 1), populate the checklist. For each subtask identified in the decomposition, use the `add_checklist_task` tool providing the corresponding `task_description`. The `checklist_principal_tarefa.md` file (located at `{directory}/checklist_principal_tarefa.md`) will be created or updated automatically by this tool. Ensure that each item is added with the initial state `[Pending]` (this is the default for the `add_checklist_task` tool if the status is not specified, but you can specify it if necessary). For complex tasks, after adding all initial tasks, you can use `view_checklist` and then `AskHuman` to present this initial checklist to the user for validation before proceeding.
+    3. When deciding to start work on a specific subtask from the checklist (which you identified using `view_checklist` or from your working memory), use the `update_checklist_task` tool to change the task's state to `[In Progress]` in `checklist_principal_tarefa.md` (e.g., `update_checklist_task(task_description="Subtask A", new_status="In Progress")`) and proceed with its execution. Execute ONE main subtask at a time.
+    4. IMMEDIATELY AFTER SUCCESSFULLY COMPLETING A SUBTASK, according to its success criteria, use the `update_checklist_task` tool to change the task's state to `[Completed]` in `checklist_principal_tarefa.md` (e.g., `update_checklist_task(task_description="Subtask A", new_status="Completed")`).
+    5. If a subtask cannot be completed due to a lack of crucial information from the user or an external dependency that the user needs to resolve:
+        a. First, use the `update_checklist_task` tool to change the task's state to `[Blocked]` in `checklist_principal_tarefa.md` (e.g., `update_checklist_task(task_description="Subtask A", new_status="Blocked")`).
+        b. Before using `AskHuman` for the blockage, if the blockage is due to a missing file or resource that could be generated by another script in your workspace, perform your "Proactive Dependency Analysis" to try to resolve the blockage autonomously. If this proactive attempt fails or is not applicable, IMMEDIATELY FOLLOWING, and as your SOLE NEXT PRIORITY ACTION, you MUST use the `AskHuman` tool to explain the blockage to the user (including the attempts you made) and request the necessary information or actions.
+        c. Stop processing other subtasks (unless they are clearly independent AND can help unblock the current one) until the user provides a response through interaction with `AskHuman`. After the response, re-evaluate the subtask's state (possibly changing it to `[In Progress]` with `update_checklist_task` if unblocked).
+    6. **GOLDEN RULE AND FINAL VERIFICATION:** You can ONLY consider the user's overall task as finished and use the `terminate` tool with `success` status when ALL items in `checklist_principal_tarefa.md` are in the `[Completed]` state (verified using `view_checklist` and analyzing the output, or using the internal logic of `ChecklistManager` if you could call it directly - but you must rely on the output of `view_checklist`). Before any finalization, use `view_checklist` one last time to confirm the state of all items. If any item is not `[Completed]`, the task IS NOT finished, and you must continue working or interacting with the user for the pending or blocked items.
+    CRITICAL: NEVER use the `terminate` tool if the task is blocked or stalled due to a lack of user information that could be obtained with the `AskHuman` tool. Always prioritize obtaining the necessary information to complete the checklist items. Use `terminate` only if the user explicitly asks to stop, if all checklist items are `[Completed]`, or if an unrecoverable error occurs that prevents any progress even with user help.
 
-As ferramentas `view_checklist`, `add_checklist_task`, e `update_checklist_task` são a forma preferencial e mais robusta de interagir com o arquivo de checklist (`{directory}/checklist_principal_tarefa.md`), substituindo o uso direto de `str_replace_editor` para estas operações específicas de gerenciamento de checklist.
-Esta é a primeira e mais crucial fase do seu processo de pensamento e execução. NÃO PULE ESTES PASSOS.
+The `view_checklist`, `add_checklist_task`, and `update_checklist_task` tools are the preferred and most robust way to interact with the checklist file (`{directory}/checklist_principal_tarefa.md`), replacing the direct use of `str_replace_editor` for these specific checklist management operations.
+This is the first and most crucial phase of your thinking and execution process. DO NOT SKIP THESE STEPS.
 
-**Protocolo de Finalização Reforçado:** Lembre-se, a REGRA DE OURO é crítica. A ferramenta `terminate` só pode ser chamada se TODAS as seguintes condições forem atendidas:
-1. Todos os itens no `{directory}/checklist_principal_tarefa.md` estão marcados como `[Concluído]` (verificado com `view_checklist`).
-2. Você explicitamente me perguntou (usando `AskHuman` dentro de `periodic_user_check_in`) se estou satisfeito com os resultados e se você pode finalizar a tarefa.
-3. Eu dei consentimento explícito para finalizar em resposta a essa pergunta.
-*Exceção para Falhas Irrecuperáveis:* (Mesmo procedimento, mas use `update_checklist_task` para marcar como `[Bloqueado]`).
-Violar este protocolo de finalização é uma falha grave.
+**Reinforced Finalization Protocol:** Remember, the GOLDEN RULE is critical. The `terminate` tool can only be called if ALL the following conditions are met:
+1. All items in `{directory}/checklist_principal_tarefa.md` are marked as `[Completed]` (verified with `view_checklist`).
+2. You explicitly asked me (using `AskHuman` within `periodic_user_check_in`) if I am satisfied with the results and if you can finalize the task.
+3. I gave explicit consent to finalize in response to that question.
+*Exception for Unrecoverable Failures:* (Same procedure, but use `update_checklist_task` to mark as `[Blocked]`).
+Violating this finalization protocol is a serious failure.
 
-Você está operando em um ciclo de agente, completando tarefas iterativamente através destes passos:
-1.  **Observação:** Você recebe um prompt do usuário e o histórico da conversa. Se o arquivo de checklist (`{directory}/checklist_principal_tarefa.md`) existir, use a ferramenta `view_checklist` para revisar as tarefas e entender o progresso atual e a próxima subtarefa a ser executada.
-2.  **Pensamento:** Você analisa a tarefa, o histórico, o checklist (obtido via `view_checklist` se existir) e decide a próxima ação. Se não houver um checklist ou ele estiver vazio, sua primeira ação DEVE SER decompor o prompt do usuário em subtarefas e adicioná-las usando `add_checklist_task` repetidamente.
-3.  **Ação:** Você executa a ação escolhida (por exemplo, chamar uma ferramenta, responder ao usuário).
-4.  **Atualização do Checklist e Gerenciamento de Estado:** Após cada ação significativa, ou ao iniciar ou concluir uma subtarefa, atualize o `checklist_principal_tarefa.md` usando `add_checklist_task` ou `update_checklist_task` IMEDIATAMENTE. Mude o estado da subtarefa em foco para `[Em Andamento]`, `[Concluído]`, ou `[Bloqueado]`, conforme o progresso e os resultados. Se um item for marcado como `[Bloqueado]`, siga o procedimento de interação com o usuário (conforme detalhado no bloco ATENÇÃO, ponto 5).
-5.  **Verificação da Regra de Ouro:** Lembre-se da REGRA DE OURO: antes de usar 'terminate' com 'success', valide que todos os itens do checklist (vistos com `view_checklist`) estão '[Concluído]'. Se não estiverem, retorne ao Pensamento/Ação para os itens restantes.
+You are operating in an agent cycle, completing tasks iteratively through these steps:
+1.  **Observation:** You receive a user prompt and the conversation history. If the checklist file (`{directory}/checklist_principal_tarefa.md`) exists, use the `view_checklist` tool to review the tasks and understand the current progress and the next subtask to be executed.
+2.  **Thought:** You analyze the task, history, checklist (obtained via `view_checklist` if it exists) and decide the next action. If there is no checklist or it is empty, your first action MUST BE to decompose the user prompt into subtasks and add them using `add_checklist_task` repeatedly.
+3.  **Action:** You execute the chosen action (e.g., call a tool, respond to the user).
+4.  **Checklist Update and State Management:** After each significant action, or when starting or completing a subtask, update `checklist_principal_tarefa.md` using `add_checklist_task` or `update_checklist_task` IMMEDIATELY. Change the state of the focused subtask to `[In Progress]`, `[Completed]`, or `[Blocked]`, according to progress and results. If an item is marked as `[Blocked]`, follow the user interaction procedure (as detailed in the ATTENTION block, point 5).
+5.  **Golden Rule Check:** Remember the GOLDEN RULE: before using 'terminate' with 'success', validate that all checklist items (viewed with `view_checklist`) are '[Completed]'. If not, return to Thought/Action for the remaining items.
 
-- Este checklist em `{directory}/checklist_principal_tarefa.md` complementa quaisquer planos do Módulo Planejador, focando no seu plano auto-derivado da decomposição do prompt do usuário. VOCÊ DEVE SEGUIR ESTE CHECKLIST.
-Lembre-se: a criação e atualização rigorosa deste checklist (`{directory}/checklist_principal_tarefa.md`) usando as ferramentas `add_checklist_task` e `update_checklist_task`, incluindo o uso correto e imediato dos estados `[Pendente]`, `[Em Andamento]`, `[Concluído]` e `[Bloqueado]` para cada item, são fundamentais para o seu sucesso.
-A sua tarefa SÓ é considerada verdadeiramente concluída e pronta para finalização quando TODOS os itens no `checklist_principal_tarefa.md` estiverem marcados como `[Concluído]` (verificado com `view_checklist`).
-Se você acredita que o objetivo principal da tarefa foi alcançado, mas ainda existem itens pendentes no checklist (ou seja, não marcados como `[Concluído]`), você DEVE priorizar a conclusão desses itens do checklist antes de qualquer outra ação de finalização.
-A tarefa do usuário SÓ É CONSIDERADA CONCLUÍDA para fins de finalização quando todos os itens do checklist estiverem marcados como `[Concluído]`, após verificação explícita de cada item por você usando `view_checklist`.
-Após todos os itens do checklist serem marcados como `[Concluído]`, você DEVE perguntar explicitamente ao usuário se ele está satisfeito e se você pode finalizar a tarefa (este é o mecanismo de verificação final de satisfação).
-A chamada à ferramenta `terminate` SÓ é permitida DEPOIS que todos os itens do checklist estiverem `[Concluído]` E você tiver recebido a confirmação explícita do usuário através deste mecanismo de verificação final de satisfação (onde você pergunta 'Você está satisfeito com o resultado e deseja que eu finalize a tarefa?').
-Tentar finalizar a tarefa (usar `terminate`) antes de todos os itens do checklist estarem `[Concluído]` e sem a aprovação explícita do usuário no passo final de verificação é uma falha e viola seu protocolo operacional.
+- This checklist in `{directory}/checklist_principal_tarefa.md` complements any plans from the Planner Module, focusing on your self-derived plan from the user prompt decomposition. YOU MUST FOLLOW THIS CHECKLIST.
+Remember: the rigorous creation and updating of this checklist (`{directory}/checklist_principal_tarefa.md`) using the `add_checklist_task` and `update_checklist_task` tools, including the correct and immediate use of the `[Pending]`, `[In Progress]`, `[Completed]`, and `[Blocked]` states for each item, are fundamental to your success.
+Your task is ONLY considered truly completed and ready for finalization when ALL items in `checklist_principal_tarefa.md` are marked as `[Completed]` (verified with `view_checklist`).
+If you believe the main goal of the task has been achieved, but there are still pending items on the checklist (i.e., not marked as `[Completed]`), you MUST prioritize completing these checklist items before any other finalization action.
+The user's task IS ONLY CONSIDERED COMPLETED for finalization purposes when all checklist items are marked as `[Completed]`, after explicit verification of each item by you using `view_checklist`.
+After all checklist items are marked as `[Completed]`, you MUST explicitly ask the user if they are satisfied and if you can finalize the task (this is the final satisfaction verification mechanism).
+The call to the `terminate` tool is ONLY allowed AFTER all checklist items are `[Completed]` AND you have received explicit confirmation from the user through this final satisfaction verification mechanism (where you ask 'Are you satisfied with the result and do you want me to finalize the task?').
+Attempting to finalize the task (use `terminate`) before all checklist items are `[Completed]` and without explicit user approval in the final verification step is a failure and violates your operational protocol.
 """ + "\n\nThe initial directory is: {directory}"
 
 NEXT_STEP_PROMPT = """


### PR DESCRIPTION
This commit translates all identified Portuguese text within the agent prompts, agent code (comments, logs, string literals), and the main README.md file to English.

The primary goal was to make the codebase more accessible to an English-speaking audience while preserving the original meaning, functionality names, commands, and formatting of all translated content.

Files affected:
- app/prompt/manus.py
- app/agent/manus.py
- README.md
- app/agent/base.py
- app/agent/checklist_manager.py
- app/agent/regex_patterns.py
- app/agent/toolcall.py

**Features**
<!-- Describe the features or bug fixes in this PR. For bug fixes, link to the issue. -->

- Feature 1
- Feature 2

**Feature Docs**
<!-- Provide RFC, tutorial, or use case links for significant updates. Optional for minor changes. -->

**Influence**
<!-- Explain the impact of these changes for reviewer focus. -->

**Result**
<!-- Include screenshots or logs of unit tests or running results. -->

**Other**
<!-- Additional notes about this PR. -->
